### PR TITLE
adding link nimble task for easier local dev

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+# repo prefers 80 char limit lines
+max_line_length = 80
+
+[*.nim]
+indent_style = space
+indent_size = 2

--- a/nimutils.nimble
+++ b/nimutils.nimble
@@ -13,8 +13,17 @@ requires "nim >= 1.6.10"
 requires "unicodedb == 0.11.1"
 requires "https://github.com/viega/nimaws == 0.3.4"
 
-let s = "nimble doc --project --git.url:https://github.com/crashappsec/nimutils.git --git.commit:v" &
-  version & " --outdir:docs --index:on src/nimutils"
+let s = "nimble doc --project" &
+  " --git.url:https://github.com/crashappsec/nimutils.git" &
+  " --git.commit:v" & version &
+  " --outdir:docs" &
+  " --index:on src/nimutils"
 
 task docs, "Build our docs":
- exec s
+  exec s
+
+let nimblePath = "~/.nimble/pkgs/nimutils-" & version & "/nimutils"
+
+task link, "Symlink nimutils to ~/.nimble for local dev":
+  exec "set -x && rm -rf " & nimblePath
+  exec "set -x && ln -s $(pwd)/src/nimutils " & nimblePath


### PR DESCRIPTION
since nimble can reset ~/.nimble/pkg when buping versions, locally I just manually checkout the dep in another folder and this allows to symlink local version into nimble pkgs folder so that you can experiment locally faster

not  sure if there is a better way

also change the doc string to be <80 chars limit and adding editorconfig so that editors can highlight the 80 char limit