### PR TITLE
fixing incompatible pointer for dup2()

### DIFF
--- a/src/nimutils/file.nim
+++ b/src/nimutils/file.nim
@@ -275,7 +275,7 @@ int c_replace_stdin_with_pipe() {
   int filedes[2];
 
   pipe(filedes);
-  dup2(filedes, 0);
+  dup2(filedes[0], 0);
   return filedes[1];
 }
 

--- a/src/nimutils/unicodeid.nim
+++ b/src/nimutils/unicodeid.nim
@@ -140,7 +140,7 @@ proc readRune*(s: Stream): Rune =
      n = n or (uint(s.readChar()) and 0x3f)
   of 4:
      n = uint(c) and (0x07 shl 18)
-     n = n or ((uint(s.readChar()) and 0x3f) shl 12)     
+     n = n or ((uint(s.readChar()) and 0x3f) shl 12)
      n = n or ((uint(s.readChar()) and 0x3f) shl 6)
      n = n or (uint(s.readChar()) and 0x3f)
   else:


### PR DESCRIPTION
otherwise getting:

```
/Users/miki725/.nimble/pkgs2/nimutils-0.4.7-137d35d56cb4ed4fd6dae2cb78498ee52f0a2dc0/nimutils/file.nim:278:8: error: incompatible pointer to integer conversion passing 'int[2]' to parameter of type 'int' [-Wint-conversion]
  dup2(filedes, 0);
       ^~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/unistd.h:440:14: note: passing argument to parameter here
int      dup2(int, int);
                 ^
```