### PR TITLE
fixing cmark headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ APIs simple and obvious.
   suffix = ""): string`, `getNewTmpFile(prefix = "tmp", suffix = "")`
   , `registerTempFile(path: string)`, and `registerTmpDir(path:
   string)`
-  
+
 - An API for cross-process locking through lock-files:
   `writeViaLockFile(path, contents: string, release = true, maxAttempts = 5):
   bool` and `readViaLockFile*(path: string, release = true, maxAttempts
@@ -68,11 +68,11 @@ APIs simple and obvious.
 
 ```nim
   const t = newFileTable(".")  # t gets set at compile time.
-  
+
   for k, v in t:
     echo "Filename: ", k
     echo "Contents: ", v
-```    
+```
 
 Our super flexible getopt style API has moved to Con4m, where you can
 now spec rich command lines without writing any code at all.
@@ -86,7 +86,7 @@ been impossible to find something good in the Nim world till now:
   message integrity via AES-GCM (which is the default TLS
   algorithm). The API is designed to handle many messages (example
   below).
-  
+
 - The AES-GCM message authentication code has an API.
 
 - There's an EASY interface to SHA2-256, SHA2-512 and SHA3. Get the

--- a/nimutils/formatstr.nim
+++ b/nimutils/formatstr.nim
@@ -1,11 +1,11 @@
 # Edited from
-#            
+#
 #           Nim's Runtime Library
 #        (c) Copyright 2017 Nim contributors
 #
 #    See the file "copying.txt", included in this
 #    distribution, for details about the copyright.
-#  
+#
 #  (c) Copyright 2022 G. Bareigts
 #
 

--- a/nimutils/headers/cmark-gfm.nim
+++ b/nimutils/headers/cmark-gfm.nim
@@ -4,12 +4,12 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include "cmark-gfm_export.h"
-#include "cmark-gfm_version.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define CMARK_GFM_EXPORT extern
 
 /** # NAME
  *

--- a/nimutils/s3client.nim
+++ b/nimutils/s3client.nim
@@ -103,4 +103,3 @@ proc list_buckets*(self: var S3Client): seq[Bucket] {.gcsafe.} =
     var xml = parseXml(res.body)
     for b in xml.findAll("Bucket"):
       result.add(Bucket(name: b[0].innerText, created: b[1].innerText))
-


### PR DESCRIPTION
not requiring cmark system headers and defining CMARK_GFM_EXPORT
which is used in the rest of the header file