### PR TITLE
adding safeRequest httpclient.request() wrapper which honors timeout

### DIFF
--- a/nimutils/process.nim
+++ b/nimutils/process.nim
@@ -12,10 +12,13 @@ import misc, strutils, posix, file, os, options
 #include <errno.h>
 #include <termios.h>
 #include <unistd.h>
-#include <util.h>
 #include <limits.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
+
+#ifdef __APPLE__
+#include <util.h>
+#endif
 
 // Already in nimutils
 extern bool write_data(int fd, char *buf, size_t nbytes);


### PR DESCRIPTION
I cant seem to be able to test this with chalk as I get missing `util.h` file so prolly would be better to test this in another way before merging