### PR TITLE
fixing http sink by not requiring ssl context

### DIFF
--- a/nimutils/sinks.nim
+++ b/nimutils/sinks.nim
@@ -413,7 +413,7 @@ proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
     elif pinnedCert != "":
       raise newException(ValueError, "Pinned cert not allowed with http " &
                                       "URL (only https).")
-    client = newHttpClient(timeout=timeout)
+    client = newHttpClient(sslContext=nil, timeout=timeout)
 
   if client == nil:
     raise newException(ValueError, "Invalid HTTP configuration")


### PR DESCRIPTION
default function signature for newHttpClient is:

```
proc newHttpClient(userAgent = defUserAgent; maxRedirects = 5;
                   sslContext = getDefaultSSL(); proxy: Proxy = nil;
                   timeout = -1; headers = newHttpHeaders()): HttpClient {
```

and so when sslContext is not provided, it would default to `getDefaultSSL()` which would require TLS certs to be installed on the system. By providing it as nil, it bypasses all TLS logic and allow to send report so http sinks without TLS certs installed on the system.