### PR TITLE
adding presign sink

### DIFF
--- a/nimutils.nim
+++ b/nimutils.nim
@@ -64,7 +64,7 @@ when isMainModule:
                                        columnInfo = widths))
 
   proc basic_subproc_tests() =
-    print(h2("Run: /bin/cat /etc/passwd /etc/file_that_doesnt_exist; " & 
+    print(h2("Run: /bin/cat /etc/passwd /etc/file_that_doesnt_exist; " &
              "show output."))
     let res = runCmdGetEverything("/bin/cat", @["/etc/passwd",
                                                 "/etc/file_that_doesnt_exist"],
@@ -302,7 +302,7 @@ when isMainModule:
     print em($int(clzp128(addr y)))
     print h3("clz for high(uint128)")
     print em($int(clzp128(addr z)))
-    
+
   proc dictTests() =
     print(h2("Dictionary tests"))
 
@@ -382,7 +382,7 @@ when isMainModule:
     print(tbl)
 
     var mess2 = @[@["1, 1", "Column 2", "Column 3", "Column 4"],
-                  @["Row 2", "has some medium length strings", 
+                  @["Row 2", "has some medium length strings",
 """This has one string that's pretty long, but the rest are short. But this one is really long. I mean, really long, long enough to drive the other column into oblivion.""", "Row 2"],
                   @["Row 3", "has some medium length strings", "Row 3", "Row 3"],
                   @["Row 4", "has some medium length strings", "Row 4", "Row 4"]]
@@ -407,8 +407,8 @@ when isMainModule:
     let t5 = t4.highlightMatches(@["medium", "the"])
     print(t5)
 
-    let t6 = atom("This has one string that's pretty long, ")  + 
-             atom("but the rest are short. But this one is ") + 
+    let t6 = atom("This has one string that's pretty long, ")  +
+             atom("but the rest are short. But this one is ") +
              atom("really long. I mean, really long, long ") +
              atom("enough to drive the other column into oblivion.")
 
@@ -472,7 +472,7 @@ Oh look, here comes a table!
   instantTableTests()
   calloutTest()
   int128Test()
-  
+
   var baddie = h1("hello") + fgColor(atom("Sup,"), "lime") + atom(" dawg!")
   print(pre(repr(baddie)))
   print(baddie)

--- a/nimutils/c/macproc.c
+++ b/nimutils/c/macproc.c
@@ -231,7 +231,7 @@ proc_list_one(size_t *count, int pid) {
     int                name[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
     size_t             i, len;
     size_t             valid    = 0;
-    int                failsafe = 0;    
+    int                failsafe = 0;
 
     while (true) {
 	err = sysctl(name, 4, NULL, &len, NULL, 0);

--- a/nimutils/int128_t.nim
+++ b/nimutils/int128_t.nim
@@ -23,7 +23,7 @@ void hex128(uint64_t *x, char *p) {
 #else
   hex64(x[0], p);
   hex64(x[1], p + 16);
-#endif 
+#endif
 }
 
 #if BYTE_ORDER == __BIG_ENDIAN
@@ -84,7 +84,7 @@ func `>`*[T: int128|uint128](x, y: T): bool =
 func high*[T: uint128](x: typedesc[T]): T =
   {.emit: "`result` = ~(__uint128_t)0;" .}
 func low*[T: uint128](x: typedesc[T]): T = 0
-func high*[T: int128](x: typedesc[T]): T = 
+func high*[T: int128](x: typedesc[T]): T =
   {.emit: "`result` = (__int128_t)~(((__uint128_t)1) << 127);" .}
 func low*[T: int128](x: typedesc[T]): T =
   {.emit: "`result` = (__int128_t)((__uint128_t)1) << 127;" .}
@@ -108,7 +108,7 @@ converter i128ToI16*(n: int128): int16 =
   {.emit: "`result` = (uint16_t)`n`;" .}
 converter i128ToI8*(n: int128): int8 =
   {.emit: "`result` = (uint8_t)`n`;" .}
-  
+
 proc `toRope`*[T: int128|uint128](x: T): string =
   var n = x
   result = newString(33)

--- a/nimutils/logging.nim
+++ b/nimutils/logging.nim
@@ -1,7 +1,7 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import tables, options, pubsub, sinks, rope_base, rope_construct, 
+import tables, options, pubsub, sinks, rope_base, rope_construct,
    rope_ansirender, rope_styles
 
 type LogLevel* = enum

--- a/nimutils/misc.nim
+++ b/nimutils/misc.nim
@@ -131,4 +131,4 @@ proc delByValue*[T](s: var seq[T], x: T): bool {.discardable.} =
 
   s.delete(ix)
 
-  return true  
+  return true

--- a/nimutils/rope_base.nim
+++ b/nimutils/rope_base.nim
@@ -130,7 +130,7 @@ type
     id*:            string
     tag*:           string
     class*:         string
-    style*:         FmtStyle  # Cached 
+    style*:         FmtStyle  # Cached
     tweak*:         FmtStyle  # temporary
     processed*:     bool
     cycle*:         bool
@@ -257,19 +257,19 @@ proc `$`*(s: FmtStyle): string =
     of AlignL:
       result &= "align=left; "
     of AlignR:
-      result &= "align=right; "      
+      result &= "align=right; "
     of AlignC:
-      result &= "align=center; "      
+      result &= "align=center; "
     of AlignJ:
-      result &= "align=justify; "      
+      result &= "align=justify; "
     of AlignF:
       result &= "align=flush; "
     else:
       discard
-    
+
 template genericRopeWalk*(r: Rope, someFunc: untyped, someData: untyped) =
   ## This is a helper template to decompose calling the next level
-  ## down in a Rope. 
+  ## down in a Rope.
   ##
   ## This only goes down a single level, and it doesn't invoke
   ## siblings so that the caller can do things after descending but
@@ -304,7 +304,7 @@ template genericRopeWalk*(r: Rope, someFunc: untyped, someData: untyped) =
 
 proc buildWalk(r: Rope, results: var seq[Rope]) =
   if r != nil:
-    results.add(r)  
+    results.add(r)
     r.genericRopeWalk(buildWalk, results)
     for item in r.siblings:
       item.buildWalk(results)

--- a/nimutils/rope_construct.nim
+++ b/nimutils/rope_construct.nim
@@ -87,7 +87,7 @@ proc noBoxRequired*(r: Rope): bool =
 
 proc boxText*(r: Rope): Rope =
   ## Place text that needs to be boxed in an unstyled box.
-  result = Rope(kind: RopeTaggedContainer, noTextExtract: true, 
+  result = Rope(kind: RopeTaggedContainer, noTextExtract: true,
                 contained: r)
 
 proc textRope*(s: string, pre = false): Rope =
@@ -227,7 +227,7 @@ proc `+`*(r1: Rope, r2: Rope): Rope =
     dupe1.text &= dupe2.text
     return dupe1
   else:
-    let 
+    let
       noBox1 = dupe1.noBoxRequired()
       noBox2 = dupe2.noBoxRequired()
 
@@ -240,37 +240,37 @@ proc `+`*(r1: Rope, r2: Rope): Rope =
     else:
       result = dupe1
       dupe1.siblings.add(dupe2.boxText())
-      
+
 
 proc link*(r1: Rope, r2: Rope): Rope =
   ## Returns the concatenation of two ropes, but WITHOUT copying them.
   ##
   ## In many cases, the object in the first operand will also be
   ## returned, but not always:
-  ## 
+  ##
   ## 1) The first parameter might end up getting boxed, since boxed
   ## content cannot live next to unboxed content.
   ##
   ## 2), if the first parameter is nil, the second param will be
   ## returned.
   ##
-  ## 
+  ##
   ## But generally, this links the two Ropes (modulo our box
   ## constraint), as opposed to `+=`, which links a copy of the rhs to
   ## the lhs, or `+` which copies both operands.
   ##
   ## We did it this way, because copying is rarely the right thing.
   ##
-  ## However, we currently are NOT checking for cycles here. Use += 
+  ## However, we currently are NOT checking for cycles here. Use +=
   ## if there might be a cycle; it will deep-copy the RHS.
-  ## 
+  ##
 
   if r1 == nil:
     return r2
   if r2 == nil:
     return r1
 
-  var 
+  var
     lastOnL: Rope
 
   if r1.siblings.len() == 0:
@@ -282,7 +282,7 @@ proc link*(r1: Rope, r2: Rope): Rope =
     lastOnL.text &= r2.text
     result = r1
   else:
-    let 
+    let
       noBox1 = r1.noBoxRequired()
       noBox2 = r2.noBoxRequired()
 
@@ -515,7 +515,7 @@ proc markdown*(s: string, add_div = true): Rope =
   ## Process the text as markdown.
   s.strip().htmlStringToRope(markdown = true, add_div = true)
 
-proc text*(s: string, pre = true, detect = false): Rope =  
+proc text*(s: string, pre = true, detect = false): Rope =
   if detect:
     let n = s.strip(trailing = false)
     if n.len() != 0:
@@ -570,7 +570,7 @@ macro tagGenRename(id: static[string], rename: static[string]): untyped =
         ## Turn a string into a rope, styled with this tag.
         return `idNode`(s.textRope(pre))
   result.add(decl)
-  
+
 macro trSetGen(ids: static[openarray[string]]): untyped =
   result = newStmtList()
 
@@ -639,12 +639,12 @@ proc container*(r: Rope): Rope =
   ## Returns a container with no formatting info; will inherit whatever.
   result = Rope(kind: RopeTaggedContainer, tag: "", contained: r,
                 noTextExtract: true)
-  
+
 proc container*(s: string): Rope =
   ## Returns a container with no formatting info; will inherit whatever.
   result = container(atom(s))
 
-proc table*(tbody: Rope, thead: Rope = nil, tfoot: Rope = nil, 
+proc table*(tbody: Rope, thead: Rope = nil, tfoot: Rope = nil,
             title: Rope = nil, caption: Rope = nil,
              columnInfo: seq[ColInfo] = @[]): Rope =
   ## Generates a Rope that outputs a table. The content parameters
@@ -671,21 +671,21 @@ proc table*(tbody: Rope, thead: Rope = nil, tfoot: Rope = nil,
 proc colWidthInfo*(input: openarray[(int, bool)]): seq[ColInfo] =
   ## This takes column information and returns what you need
   ## to pass to `table()`.
-  ## 
+  ##
   ## The inputs are two-tuples. If the boolean is true, then the
   ## integer is interpreted as an absolute column width. If it's
   ## false, then it's interpreted as a percent.
   ##
   ## Use a percentage of 0 to signal flexible with, based on available
   ## space. If multiple columns have this value, they'll be given
-  ## equal space. 
+  ## equal space.
   ##
   ## Note that, if you do not specify any values for a table at all,
   ## the system will try to do more intelligent auto-sizing.
 
   for (v, b) in input:
     result.add(ColInfo(span: 0, wValue: v, absVal: b))
-    
+
 proc colPcts*(pcts: openarray[int]): seq[ColInfo] =
   ## This takes a list of column percentages and returns what you need
   ## to pass to `table()`.
@@ -741,7 +741,7 @@ proc nocolors*(r: Rope, removeNested = true): Rope =
   if removeNested:
     for item in r.search("colors"):
       item.tag = "nocolors"
-      
+
 basicTagGen(["h1", "h2", "h3", "h4", "h5", "h6",
              "li", "blockquote", "div", "code", "ins", "del", "kbd", "mark",
              "small", "sub", "sup", "width", "title", "em", "strong",
@@ -787,7 +787,7 @@ proc inlineCode*(s: string): Rope =
   if s == "":
     return Rope(nil)
   else:
-    return Rope(kind: RopeTaggedContainer, tag: "inline", 
+    return Rope(kind: RopeTaggedContainer, tag: "inline",
                 contained: s.text(pre = false))
 
 proc join*(l: seq[Rope], s: Rope): Rope =
@@ -814,11 +814,11 @@ proc copyToBreakInternal(r: Rope, truncated: var bool,
   r.cycle = true
 
   result = Rope(kind: r.kind, tag: r.tag, class: r.class)
-  
+
   if r.id != "" and r.id in perIdStyles:
     result.ensureUniqueId()
     perIdStyles[result.id] = perIdStyles[r.id]
-  
+
   case r.kind
   of RopeAtom:
     result.length = r.length
@@ -856,14 +856,14 @@ proc copyToBreakInternal(r: Rope, truncated: var bool,
       result.siblings.add(newsib)
 
 proc copyToBreak*(r: Rope, addDots = true): Rope =
-  ## Copies a rope up until the first break. Thie will NOT go into 
+  ## Copies a rope up until the first break. Thie will NOT go into
   ## tables or lists.
-  var 
+  var
     truncated: bool
     okToEnterContainer = true
 
   result = r.copyToBreakInternal(truncated, okToEnterContainer)
-  
+
   if truncated and addDots:
     result = result.link(atom("…"))
 

--- a/nimutils/rope_htmlrender.nim
+++ b/nimutils/rope_htmlrender.nim
@@ -9,7 +9,7 @@ proc element(name, contents: string): string =
 
 proc nobreak(name, contents: string): string =
   result = "<" & name & ">" & contents  & "</" & name & ">"
-  
+
 proc toHtml*(r: Rope, indent = 0): string =
   ## An verty basic rope-to-html generator.. Currently does NOT
   ## preserve colors, fixed width, classes, IDs, custom tags, etc.  It
@@ -20,12 +20,12 @@ proc toHtml*(r: Rope, indent = 0): string =
 
   case r.kind
   of RopeAtom:
-    result = $(r.text) 
+    result = $(r.text)
   of RopeBreak:
     if r.guts != nil:
       result = element("p", r.guts.toHtml())
     else:
-      result = "<br>\n" 
+      result = "<br>\n"
   of RopeLink:
     result = "<a href=" & r.url & ">" & r.toHighlight.toHtml() & "</a>"
   of RopeList:
@@ -85,10 +85,9 @@ proc toHtml*(r: Rope, indent = 0): string =
         var cell = item.toHtml()
         if cell.startswith("<td>") or cell.startswith("<th>"):
           cells.add(cell)
-        else: 
+        else:
           cells.add(element("td", cell))
       result = cells.join("\n")
 
   for item in r.siblings:
     result &= item.toHtml()
-      

--- a/nimutils/rope_prerender.nim
+++ b/nimutils/rope_prerender.nim
@@ -7,7 +7,7 @@
 # Everything else on my original wishlist is here now though.
 
 
-import tables, options, std/terminal, rope_base, rope_construct, rope_styles, 
+import tables, options, std/terminal, rope_base, rope_construct, rope_styles,
        unicodeid, unicode, misc
 
 type
@@ -55,7 +55,7 @@ proc unboxedRuneLength(r: Rope, results: var int) =
     r.genericRopeWalk(unboxedRuneLength, results)
     for item in r.siblings:
       item.unboxedRuneLength(results)
-    
+
 proc unboxedRuneLength*(r: Rope): int =
   ## Returns the approximate display-width of a rope, without
   ## considering the size of 'box' we're going to try to fit it into.
@@ -69,7 +69,7 @@ proc unboxedRuneLength*(r: Rope): int =
   ## Unicode standard. But there may occasionally be length
   ## calculation issues due to local fonts, etc.
   r.unboxedRuneLength(result)
-  
+
 
 template runelength*(r: Rope): int = r.unboxedRuneLength()
 
@@ -127,7 +127,7 @@ proc applyPadding(state: FmtState, box: RenderBox, lpad, rpad: int) =
     elif toFill > 0:
       box.contents.lines[i] = box.contents.lines[i] & state.pad(toFill)
 
-    
+
     box.contents.lines[i] = lpadTxt & box.contents.lines[i] & rpadTxt
 
 proc wrapTextPlane(p: TextPlane, lineStart, lineEnd: seq[uint32]) =
@@ -180,11 +180,11 @@ proc popStyle(state: var FmtState) =
 proc getNewStartStyle(state: FmtState, r: Rope): FmtStyle =
   if r == nil:
     return state.curStyle
-  
+
   # If there's an explicit style set, and no tweak, we are ok.
   if r.style != nil and r.tweak == nil:
     return r.style
-  
+
   # First, apply any style object associated with the rope's html tag.
   # Second, if the rope has a class, apply any style object associated w/ that.
   # Third, do the same w/ ID.
@@ -271,7 +271,7 @@ template applyContainerStyle(boxvar: untyped, code: untyped) =
     state.applyAlignment(collapsed)
     state.applyPadding(collapsed, lpad, rpad)
   boxvar = @[collapsed]
-  state.popStyle()    
+  state.popStyle()
 
 proc preRender*(state: var FmtState, r: Rope): seq[RenderBox]
 
@@ -383,7 +383,7 @@ proc getGenericBorder(state: var FmtState, colWidths: seq[int],
     for i, width in colWidths:
       for j in 0 ..< width:
         result &= uint32(horizontal)
-        
+
       if useSep and i != len(colWidths) - 1:
         result &= uint32(sep)
 
@@ -408,11 +408,11 @@ proc getAvailableSpace(state: var FmtState, r: Rope, n: int): int =
   if state.curStyle.useLeftBorder.getOrElse(false):
     result -= 1
   if state.curStyle.useRightBorder.getOrElse(false):
-    result -= 1  
+    result -= 1
   if state.curStyle.useVerticalSeparator.getOrElse(false):
     result -= (n - 1)
-  
-proc calculateColumnWidths(state: var FmtState, r: Rope, 
+
+proc calculateColumnWidths(state: var FmtState, r: Rope,
                            colInfo: seq[ColInfo]): seq[int] =
   # Percent is treated as a percent of AVAILABLE column width, meaning
   # after border overhead is removed.
@@ -457,7 +457,7 @@ proc guessColWidths(state: var FmtState, r: Rope): seq[ColInfo] =
   # 3) For other columns, We give out width proportional to the total
   #    num of chars in each column.
   # 4) Anything available at the end is evenly distributed.
-  
+
   var
     happy:       seq[bool]
     maxWidths:   seq[int]
@@ -491,7 +491,7 @@ proc guessColWidths(state: var FmtState, r: Rope): seq[ColInfo] =
 
   if len(maxWidths) <= 1:
     return  @[ColInfo(span: 0, wValue: 0, absVal: false)]
-  
+
   var evenDivision = (available div maxWidths.len())
 
   for i in 0 ..< happy.len():
@@ -508,7 +508,7 @@ proc guessColWidths(state: var FmtState, r: Rope): seq[ColInfo] =
 
   # See if there's enough nicked space to make columns happy.
   for i, width in maxWidths:
-    if happy[i]: 
+    if happy[i]:
       continue
     let needed = (width + 2) - result[i].wValue
     if needed < available:
@@ -524,20 +524,20 @@ proc guessColWidths(state: var FmtState, r: Rope): seq[ColInfo] =
   var proportionalSpace = available
 
   for i in 0 ..< totalWidths.len():
-    if happy[i]: 
+    if happy[i]:
       continue
     sum += totalWidths[i]
-    
+
   if sum != 0:
     for i, width in totalWidths:
       if available <= 0:
         break
       if happy[i]:
         break
-      var 
+      var
         myPct = (width * 100) div sum
         v     = (myPct * proportionalSpace) div 100
-    
+
       result[i].wValue += v
       available -= v
 
@@ -553,7 +553,7 @@ proc guessColWidths(state: var FmtState, r: Rope): seq[ColInfo] =
     for i, width in totalWidths:
       if available <= 0:
         break
-      var 
+      var
         myPct = (width * 100) div sum
         v     = (myPct * proportionalSpace) div 100
 
@@ -561,7 +561,7 @@ proc guessColWidths(state: var FmtState, r: Rope): seq[ColInfo] =
       available -= v
 
   result[^1].wValue += available
-    
+
 proc preRenderTable(state: var FmtState, r: Rope): seq[RenderBox] =
     var
       colWidths: seq[int]
@@ -573,7 +573,7 @@ proc preRenderTable(state: var FmtState, r: Rope): seq[RenderBox] =
       colInfo = state.guessColWidths(r)
     else:
       colInfo = r.colInfo
-          
+
     colWidths = state.calculateColumnWidths(r, colInfo)
     state.pushTableWidths(colWidths)
 
@@ -780,7 +780,7 @@ template textExit(r: Rope) =
   for item in r.siblings:
     result &= state.preRender(item)
   return
-  
+
 proc preRender(state: var FmtState, r: Rope): seq[RenderBox] =
   # This is the actual main worker for rendering. Generally, these
   # ropes are trees that may be concatenated, so we need to go down
@@ -808,14 +808,14 @@ proc preRender(state: var FmtState, r: Rope): seq[RenderBox] =
     return
 
   r.processed = true
-  
+
   case r.kind
   of RopeAtom:
     state.preRenderAtom(r)
     r.textExit()
   of RopeLink:
     state.preRenderLink(r)
-    r.textExit()    
+    r.textExit()
   of RopeFgColor, RopeBgColor:
     withRopeStyle:
       result = state.preRender(r.toColor)
@@ -874,7 +874,7 @@ proc preRender(state: var FmtState, r: Rope): seq[RenderBox] =
          else:
            result &= state.preRenderOrderedList(r)
   of RopeTable:
-    state.tableEven.add(false)    
+    state.tableEven.add(false)
     enterContainer:
       applyContainerStyle(result):
           result &= state.preRenderTable(r)
@@ -899,7 +899,7 @@ proc preRender(state: var FmtState, r: Rope): seq[RenderBox] =
 
   for item in r.siblings:
     result &= state.preRender(item)
-  
+
 proc preRender*(r: Rope, width = -1, showLinkTargets = false,
                 style = defaultStyle): TextPlane =
   ## This takes a Rope that is essentially stored as a tree annotated
@@ -920,24 +920,24 @@ proc preRender*(r: Rope, width = -1, showLinkTargets = false,
                        curPlane: TextPlane(lines: @[]))
 
   state.pushStyle(defaultStyle.mergeStyles(style))
-    
+
   if width <= 0:
     state.totalWidth = terminalWidth() + width
   else:
     state.totalWidth = width
-      
+
   var
-    preRenderBoxes = state.preRender(r)    
+    preRenderBoxes = state.preRender(r)
     noBox: bool
 
   while state.renderStack.len() != 0:
     preRenderBoxes &= state.preRender(state.renderStack.pop())
-    
+
   # If we had text linked at the end that started after the last container
   # closed, then we will need to get that in here. We can check here to see
   # if there were any breaks, and if there weren't, skip the collapse.
   flushCurPlane(preRenderBoxes)
-  
+
   if preRenderBoxes.len() == 0:
     nobox = true
 
@@ -956,7 +956,7 @@ proc preRender*(r: Rope, width = -1, showLinkTargets = false,
     result.softBreak = true
 
 proc asUtf8*(r: Rope, width = high(int)): string =
-  ## Return a string that has padding and alignment applied, but no other 
+  ## Return a string that has padding and alignment applied, but no other
   ## styling.
 
   let box = nocolors(r).preRender(width)

--- a/nimutils/rope_styles.nim
+++ b/nimutils/rope_styles.nim
@@ -362,14 +362,14 @@ styleMap = { # Starting theme. Need to redo this to be a real theme API soon.
                              bgColor = "black", fgColor = "tomato",
                              italic = ItalicOn)
     }.toTable()
-    
+
 var
   defaultStyle* = plainStyle
   perClassStyles* = {
       "callout"   : newStyle(fgColor = "fandango", bgColor = "jazzberry",
                              italic = ItalicOn, casing = CasingTitle)
-    }.toTable()  
-    
+    }.toTable()
+
 {.emit: """
 #include <stdatomic.h>
 #include <stdint.h>
@@ -388,13 +388,13 @@ var debugId = 0
 type WalkInfo = object
   str: string
   nest: int
-    
+
 proc repr(r: Rope, res: var WalkInfo) =
   if r == nil:
     return
 
   var one = ""
-  
+
   case r.kind
   of RopeAtom:
     one &= "TEXT: " & $(r.text)
@@ -410,7 +410,7 @@ proc repr(r: Rope, res: var WalkInfo) =
   of RopeList, RopeTableRow, RopeTableRows:
     one &= r.tag & ": "
   of RopeTable:
-    one &= "TABLE: " 
+    one &= "TABLE: "
     if r.thead != nil:
       one &= "THEAD: " & $(r.thead.cells.len()) & "rows"
     if r.tbody != nil:
@@ -443,15 +443,15 @@ proc repr(r: Rope, res: var WalkInfo) =
   res.nest += 1
   r.genericRopeWalk(repr, res)
   res.nest -= 1
-  
-  for item in r.siblings: 
+
+  for item in r.siblings:
     item.repr(res)
-        
+
 proc repr*(r: Rope): string =
   ## Return a debug representation of a rope.
 
   var info: WalkInfo
-  
+
   r.repr(info)
   return info.str
 
@@ -555,7 +555,7 @@ proc isContainer*(r: Rope): bool =
 
   if r.tag in breakingStyles or r.noTextExtract:
     return true
-    
+
   case r.kind
   of RopeAtom, RopeLink, RopeFgColor, RopeBgColor:
     return false
@@ -570,14 +570,14 @@ proc isContainer*(r: Rope): bool =
     return false
 
 template defaultBoxStyle*(): BoxStyle =
-  ## Return the default box style, taken from the current value of 
+  ## Return the default box style, taken from the current value of
   ## the 'table' style, if set.
 
   if "table" in styleMap:
     styleMap["table"].boxStyle.get(BoxStylePlain)
   else:
     BoxStylePlain
-  
+
 template defaultBorderStyle*(): BorderOpts =
   ## Return the default border style.
 
@@ -650,7 +650,7 @@ proc ropeStyle*(r:     Rope,
 
   if r == nil:
     return
-    
+
   if container and not r.isContainer():
     let c = r.findFirstContainer()
     discard c.ropeStyle(style, recurse, container)
@@ -684,7 +684,7 @@ proc colWidths*(r: Rope, info: seq[ColInfo]): Rope {.discardable.} =
     item.colInfo = info
 
   return r
-  
+
 proc colWidths*(r: Rope, vals: openarray[(int, bool)]): Rope {.discardable.} =
   ## Set column widths in the first table contained within a rope.
   ## Different from `colWidthInfo` in that it applies values, whereas
@@ -695,9 +695,9 @@ proc colWidths*(r: Rope, vals: openarray[(int, bool)]): Rope {.discardable.} =
 
   for (n, b) in vals:
     info.add(ColInfo(span: 1, wValue: n, absVal: b))
-    
+
   return r.colWidths(info)
-  
+
 proc colAbs*(r: Rope, pcts: openarray[int]): Rope {.discardable.} =
   ## Similar to `colWidths`, except all inputs are treated as absolute
   ## column widths.
@@ -718,12 +718,12 @@ proc colPcts*(r: Rope, pcts: openarray[int]): Rope {.discardable.} =
     return
 
   var info: seq[ColInfo]
-  
+
   for item in pcts:
     info.add(ColInfo(span: 1, wValue: item))
 
   return r.colWidths(info)
-  
+
 proc applyClass*(r: Rope, class: string, recurse = true): Rope {.discardable.} =
   ## Set the `class` property on a rope. By default, recurses to any
   ## sub-ropes.
@@ -839,12 +839,12 @@ proc fgColor*(s: string, color: string): Rope =
   else:
     return text(s).fgColor(color)
 
-proc color*(r: Rope, fgColor: string, bgColor = "", recurse = false): 
+proc color*(r: Rope, fgColor: string, bgColor = "", recurse = false):
                                      Rope {.discardable.} =
   ## Applies fg/bg colors. By default, this is NOT recursive.
 
   return r.ropeStyle(newStyle(fgColor = fgColor, bgColor = bgColor), recurse)
-                              
+
 proc color*(s: string, fgColor: string, bgColor = ""): Rope =
   ## Returns a new Rope from a string with the given fg and (optional)
   ## background color.
@@ -858,7 +858,7 @@ proc tpad*(r: Rope, n: int, recurse = false): Rope {.discardable.} =
   ## By default, this is NOT recursive.
 
   return r.ropeStyle(newStyle(tpad = n), recurse, true)
-  
+
 proc tpad*(s: string, n: int): Rope =
   ## Adds a top pad to a string.
   return text(s).tpad(n)
@@ -869,7 +869,7 @@ proc bpad*(r: Rope, n: int, recurse = false): Rope {.discardable.} =
   ##
   ## By default, this is NOT recursive.
 
-  return r.ropeStyle(newStyle(bpad = n), recurse, true)  
+  return r.ropeStyle(newStyle(bpad = n), recurse, true)
 
 proc bpad*(s: string, n: int): Rope =
   ## Adds a bottom pad to a string.
@@ -1054,7 +1054,7 @@ proc overflow*(r: Rope, overflow: OverflowPreference, recurse = true): Rope
   {.discardable.} =
   ## Sets the overflow strategy. If you set OIntentWrap then you can
   ## change the wrap hang value via `setHang()`.
-  ## 
+  ##
   ## Recursive by default.
 
   return r.ropeStyle(newStyle(overflow = overflow), recurse)
@@ -1072,7 +1072,7 @@ proc hang*(r: Rope, hang: int, recurse = true): Rope {.discardable.} =
 
 proc bold*(r: Rope, disable = false, recurse = true): Rope {.discardable.} =
   ## Sets the `bold` property of a Rope's style. By default,
-  ## turns on the property, unless `disable` is true. 
+  ## turns on the property, unless `disable` is true.
   ##
   ## Recursive by default.
 
@@ -1092,7 +1092,7 @@ proc bold*(s: string): Rope =
 
 proc inverse*(r: Rope, disable = false, recurse = true): Rope {.discardable.} =
   ## Sets the `inverse` property of a Rope's style. By default,
-  ## turns on the property, unless `disable` is true. 
+  ## turns on the property, unless `disable` is true.
   ##
   ## Recursive by default.
 
@@ -1113,7 +1113,7 @@ proc inverse*(s: string): Rope =
 proc strikethrough*(r: Rope, disable = false, recurse = true):
                   Rope {.discardable.} =
   ## Sets the `strikethrough` property of a Rope's style. By default,
-  ## turns on the property, unless `disable` is true. 
+  ## turns on the property, unless `disable` is true.
   ##
   ## Recursive by default.
 
@@ -1133,10 +1133,10 @@ proc strikethrough*(s: string): Rope =
 
 proc italic*(r: Rope, disable = false, recurse = true): Rope {.discardable.} =
   ## Sets the `italic` property of a Rope's style. By default,
-  ## turns on the property, unless `disable` is true. 
+  ## turns on the property, unless `disable` is true.
   ##
   ## Recursive by default.
-  
+
   var param: ItalicPref
 
   if disable:
@@ -1154,7 +1154,7 @@ proc italic*(s: string): Rope =
 proc underline*(r: Rope, kind = UnderlineSingle, recurse = true):
               Rope {.discardable.} =
   ## Sets the `underline` property of a Rope's style. By default,
-  ## turns on the property, unless `disable` is true. 
+  ## turns on the property, unless `disable` is true.
   ##
   ## Recursive by default.
 
@@ -1200,17 +1200,17 @@ proc flushJustify*(r: Rope, recurse = false): Rope {.discardable.} =
   ## only set the preference on the top rope, not any children.
   return r.ropeStyle(newStyle(align = AlignF), recurse)
 
-proc multiFindFirst*(s: string, terms: var seq[string], 
+proc multiFindFirst*(s: string, terms: var seq[string],
                      start = 0): (int, string) =
   ## This is used to highlight text substring matches. The arguments
   ## are all unstyled strings, not ropes.
 
-  var 
+  var
     stillThere: seq[string] = @[]
     lowest:     uint        = high(uint)
     lowVal:     string      = ""
   for i, item in terms:
-    if item == "": 
+    if item == "":
       continue
     let ix = s.find(item, start)
     if ix == -1:
@@ -1222,13 +1222,13 @@ proc multiFindFirst*(s: string, terms: var seq[string],
 
   terms = stillThere
   result = (cast[int](lowest), lowVal)
-  
+
 proc explode*(s: string, inTerms: seq[string]): seq[string] =
   ## Like split(), except takes multiple words as input to split on,
   ## and returns matches as part of the array; all odd indexes will be
   ## matches.
 
-  var 
+  var
     terms   = inTerms
     startix = 0
 
@@ -1268,7 +1268,7 @@ type MatchInfo = object
   classToAdd:   string
 
 proc highlightMatches(r: Rope, info: var MatchInfo) =
-  var myMatchInfo: MatchInfo 
+  var myMatchInfo: MatchInfo
 
   if r == nil:
     return
@@ -1282,7 +1282,7 @@ proc highlightMatches(r: Rope, info: var MatchInfo) =
   if r.kind == RopeAtom:
     let asStr    = toLowerAscii($(r.text))
     var exploded = asStr.explode(info.terms)
-    
+
     if exploded.len() != 1:
       var newRope, prev, n: Rope
 
@@ -1344,14 +1344,14 @@ proc highlightMatches*(r: Rope, terms: seq[string], class = ""): Rope =
   ##
   ## Note that this does NOT do full-word matching.  So if you search
   ## for 'the', if will highlight the middle characters of 'other'.
-  
+
 
   var info = MatchInfo(terms: terms, classToAdd: class)
   r.highlightMatches(info)
   if info.replacements.len() == 0:
     return r
   return info.replacements[0][1]
-  
+
 
 proc installTheme*(tagStyles:   var Table[string, FmtStyle],
                    classStyles: var Table[string, FmtStyle]) =
@@ -1422,7 +1422,7 @@ proc useCrashTheme*() =
                              fgColor = c0Text, align = AlignL, lpad = 1,
                              rpad = 1),
       "th"        : newStyle(bgColor = c0Bg1, bold = BoldOn, overflow = OWrap,
-                           casing = CasingUpper, tpad = 1, bpad = 0, lpad = 1, 
+                           casing = CasingUpper, tpad = 1, bpad = 0, lpad = 1,
                            rpad = 1, fgColor = c0Accent2, align = AlignC),
       "tr"        : newStyle(lpad = 0, rpad = 0,
                              overflow = OWrap, tpad = 0, bpad = 0),
@@ -1445,7 +1445,7 @@ proc useCrashTheme*() =
                              bpad = 1, tpad = 0, align = AlignC,
                              italic = ItalicOn)
     }.toTable()
-    
+
     classStyles = {
       "callout"   : newStyle(fgColor = "fandango", bgColor = "jazzberry",
                              italic = ItalicOn),
@@ -1455,4 +1455,3 @@ proc useCrashTheme*() =
   defaultStyle = defaultStyle.mergeStyles(tagStyles["basic"])
 
   installTheme(tagStyles, classStyles)
-  

--- a/nimutils/texttable.nim
+++ b/nimutils/texttable.nim
@@ -1,10 +1,10 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import rope_base, rope_construct, rope_prerender, rope_styles, unicode, 
+import rope_base, rope_construct, rope_prerender, rope_styles, unicode,
        unicodeid, std/terminal, tables, sugar
 
-proc instantTable*[T: string|Rope](cells: openarray[T], title = Rope(nil), 
+proc instantTable*[T: string|Rope](cells: openarray[T], title = Rope(nil),
                                     caption = Rope(nil),
                                     width = 0, borders = defaultBorderStyle(),
                                     boxStyle = defaultBoxStyle()): Rope =
@@ -33,11 +33,11 @@ proc instantTable*[T: string|Rope](cells: openarray[T], title = Rope(nil),
       maxWidth = w
 
   numcol = remainingWidth div (maxWidth + 3)
-  
+
   if numcol == 0: numcol = 1
   if numcol > cells.len():
     numcol = cells.len()
-    
+
   for i, item in cells:
     if i != 0 and i mod numcol == 0:
       rows.add(tr(row))
@@ -57,13 +57,13 @@ proc instantTable*[T: string|Rope](cells: openarray[T], title = Rope(nil),
   result = table(tbody(rows), title = title(title), caption = caption(caption))
   result.setBorders(borders).boxStyle(boxStyle).colPcts(pcts)
   result = result.setWidth(remainingWidth)
-  
+
 proc instantTable*[T: string|Rope](cells: openarray[T], title: string,
                                    caption = "", width = 0,
                                    borders = defaultBorderStyle(),
                                    boxStyle = defaultBoxStyle()): Rope =
   result = instantTable[T](cells, atom(title), atom(caption), width, borders,
-                            boxStyle)  
+                            boxStyle)
 
 template quickTableNoHeaders[T: string|Rope](cells: seq[seq[T]],
                               tableTitle: Rope, tableCaption: Rope): Rope =
@@ -157,16 +157,16 @@ proc callOut*[T: string | Rope](contents: T, width = 0, borders = BorderAll,
   var box = container(contents)
 
   box.center.tpad(1).bpad(1).lpad(1).rpad(1)
-  
+
   result = quickTable(@[@[box]], false, false, Rope(nil), Rope(nil), width,
                       borders, boxStyle)
 
   result.searchOne(@["th", "td"]).get().tpad(0).bpad(0)
-  
+
   for item in result.ropeWalk():
     item.class = "callout"
 
-type 
+type
   TreeRopeWalker*[T] = (T) -> (Rope, seq[T])
   WalkState[T] = object
     walker:     TreeRopeWalker[T]
@@ -189,7 +189,7 @@ proc quickTree[T](cur: T, state: var WalkState): Rope =
   if len(kids) == 0:
     return
 
-  var 
+  var
     padStr:  seq[Rune]
     lastPad: seq[Rune]
 
@@ -206,7 +206,7 @@ proc quickTree[T](cur: T, state: var WalkState): Rope =
   for i in 0 ..< state.vpad:
     padstr.add(state.hChar)
     lastPad.add(state.hChar)
-  
+
   for i, kid in kids:
     if i == kids.len() - 1:
       state.padStr = lastPad
@@ -214,10 +214,10 @@ proc quickTree[T](cur: T, state: var WalkState): Rope =
       state.padStr = padStr
 
     result += quickTree[T](kid, state)
-  
+
 
 proc quickTree*[T](root: T, walker: TreeRopeWalker[T], tChar = Rune(0x251c),
-                   lChar = Rune(0x2514), hChar = Rune(0x2500), 
+                   lChar = Rune(0x2514), hChar = Rune(0x2500),
                    vChar = Rune(0x2502), vpad = 2, noNewlines = true): Rope =
   var state = WalkState[T](walker: walker, tChar: tChar, lChar: lChar,
                            hChar: hChar, vChar: vChar, vpad: vpad,

--- a/nimutils/unicodeid.nim
+++ b/nimutils/unicodeid.nim
@@ -355,7 +355,7 @@ proc indentWrap*( s: string,
 proc u32LineLength*(line: seq[uint32]): int =
   ## Returns the expected renderable length of a string... the sum of
   ## the `runewidth` for all codepoints in the string.
-  ## 
+  ##
   ## Operates on our internal u32 representation.
 
   for item in line:


### PR DESCRIPTION
This allows for a flow:

* PUT request is made to provided URL (without report)
* 302/307 response is received with Location signed URL
* PUT request is made to redirected signed URL with full report

As a result chalk can send a report to S3 presigned URLs without directly access to S3 bucket.

Note the optimization that initial request does not send report as:

* we know we will be reuploading it after redirect so no need to waste bandwidth
* server might not even be able to accept it (for large reports) which is why server might be using presigned sink to begin with (e.g. AWS LB has hardcoded upload limits)