### PR TITLE
adding basic+jwt auth methods to post/presign sinks

### DIFF
--- a/nimutils.nim
+++ b/nimutils.nim
@@ -11,13 +11,13 @@
 ## few fixes have all been for compatability and are made under the
 ## same license. I also migrated the crypto to openssl.
 
-import nimutils/[box, random, unicodeid, pubsub, sinks, misc, texttable, dict],
+import nimutils/[box, random, unicodeid, pubsub, sinks, auth, misc, texttable, dict],
        nimutils/[file, filetable, encodings, advisory_lock, progress],
        nimutils/[sha, aes, prp, hexdump, markdown, htmlparse, net, colortable],
        nimutils/[rope_base, rope_styles, rope_construct, rope_prerender],
        nimutils/[rope_ansirender, rope_htmlrender, rope_textrender],
        nimutils/[switchboard, subproc, int128_t]
-export box, random, unicodeid, pubsub, sinks, misc, random, texttable,
+export box, random, unicodeid, pubsub, sinks, auth, misc, random, texttable,
        file, filetable, encodings, advisory_lock, progress, sha,
        aes, prp, hexdump, markdown, htmlparse, net, colortable, rope_base,
        rope_styles, rope_construct, rope_prerender, rope_ansirender,

--- a/nimutils/auth.nim
+++ b/nimutils/auth.nim
@@ -1,0 +1,45 @@
+import tables, std/[base64, httpclient, times]
+import jwt, pubsub
+
+proc jwtValidate(auth: AuthConfig) =
+  let token = parseJwtToken(auth.params["token"])
+  if token.isExpired():
+    raise newException(ValueError, "JWT token has expired since " & $(token.payload.exp))
+
+proc jwtInjectHeaders(auth: AuthConfig, headers: HttpHeaders): HttpHeaders =
+  let token = auth.params["token"]
+  headers["Authorization"] = "Bearer " & token
+  return headers
+
+proc basicInjectHeaders(auth: AuthConfig, headers: HttpHeaders): HttpHeaders =
+  let
+    creds   = auth.params["username"] & ":" & auth.params["password"]
+    encoded = base64.encode(creds)
+  headers["Authorization"] = "Basic " & encoded
+  return headers
+
+proc addJwtAuth*() =
+  let
+    record = AuthImplementation()
+    keys = {
+      "token": true,
+    }.toTable()
+  record.validate      = jwtValidate
+  record.injectHeaders = jwtInjectHeaders
+  record.keys          = keys
+  registerAuth("jwt", record)
+
+proc addBasicAuth*() =
+  let
+    record = AuthImplementation()
+    keys = {
+      "username": true,
+      "password": true,
+    }.toTable()
+  record.injectHeaders = basicInjectHeaders
+  record.keys          = keys
+  registerAuth("basic", record)
+
+proc addDefaultAuths*() =
+  addJwtAuth()
+  addBasicAuth()

--- a/nimutils/auth.nim
+++ b/nimutils/auth.nim
@@ -1,5 +1,63 @@
-import tables, std/[base64, httpclient, times]
-import jwt, pubsub
+## Module for various reusable auth implementations
+##
+## Auth implementations are stand-alone and can be used together
+## with sinks however can be used outside of them directly.
+##
+## Currently these auth methods are implemented:
+## * basic auth
+## * JWT
+
+import options, sugar, tables, std/[base64, httpclient, times]
+import jwt
+
+type
+  AuthParams *      = OrderedTableRef[string, string]
+  ValidateCallback* = ((AuthConfig) -> void)
+  HeadersCallback*  = ((AuthConfig, HttpHeaders) -> HttpHeaders)
+
+  AuthImplementation* = ref object
+    name*:          string
+    keys*:          Table[string, bool]
+    validate*:      ValidateCallback
+    injectHeaders*: HeadersCallback
+
+  AuthConfig* = ref object
+    name*:           string
+    implementation*: AuthImplementation
+    params*:         AuthParams
+
+var allAuths:   Table[string, AuthImplementation]
+
+proc registerAuth*(name: string, auth: AuthImplementation) =
+  auth.name      = name
+  allAuths[name] = auth
+
+proc getAuthImplementation*(name: string): Option[AuthImplementation] =
+  if name in allAuths:
+    return some(allAuths[name])
+  return none(AuthImplementation)
+
+proc ensureParamsHaveKeys*(params: AuthParams,
+                           keys: Table[string, bool]) =
+  for k, v in params:
+    if k notin keys:
+      raise newException(ValueError, "Extraneous key: " & k)
+
+  for k, v in keys:
+    if v and k notin params:
+      raise newException(ValueError, "Required key missing: " & k)
+
+proc configAuth*(a: AuthImplementation,
+                 name: string,
+                 `params?`: Option[AuthParams] = none(AuthParams)
+                 ): Option[AuthConfig] =
+  let
+    params = `params?`.get(newOrderedTable[string, string]())
+    auth   = AuthConfig(name: name, implementation: a, params: params)
+  ensureParamsHaveKeys(params, a.keys)
+  if a.validate != nil:
+    a.validate(auth)
+  return some(auth)
 
 proc jwtValidate(auth: AuthConfig) =
   let token = parseJwtToken(auth.params["token"])

--- a/nimutils/jwt.nim
+++ b/nimutils/jwt.nim
@@ -1,3 +1,7 @@
+## Generic utility module for dealing with JWT tokens
+## For now it extracts json paylods from JWT tokens as well
+## has utility methods for checking if JWT token has expired
+
 import strutils, std/[base64, json, times]
 
 type
@@ -27,6 +31,7 @@ template base64Pad(data: string): string =
   data & "=".repeat(len(data) mod 4)
 
 proc parseJwtToken*(token: string): JwtToken =
+  ## Parse JWT Token
   let parts = token.split(".")
   if len(parts) != 3:
     raise newException(ValueError, "Invalid JWT")

--- a/nimutils/jwt.nim
+++ b/nimutils/jwt.nim
@@ -1,0 +1,44 @@
+import strutils, std/[base64, json, times]
+
+type
+  JwtHeader* = ref object
+    json*: JsonNode
+
+  JwtPayload* = ref object
+    exp*:  Time
+    json*: JsonNode
+
+  JwtToken* = ref object
+    header*:    JwtHeader
+    payload*:   JwtPayload
+    signature*: string
+    value*:     string
+
+proc `$`*(token: JwtToken): string =
+  return token.value
+
+template isExpired*(token: JwtToken): bool =
+  (fromUnix(0) < token.payload.exp) and (token.payload.exp < getTime())
+
+template isStillAlive*(token: JwtToken): bool =
+  not (token.isExpired())
+
+template base64Pad(data: string): string =
+  data & "=".repeat(len(data) mod 4)
+
+proc parseJwtToken*(token: string): JwtToken =
+  let parts = token.split(".")
+  if len(parts) != 3:
+    raise newException(ValueError, "Invalid JWT")
+  let
+    headerJson  = parseJson(base64.decode(base64Pad(parts[0])))
+    payloadJson = parseJson(base64.decode(base64Pad(parts[1])))
+    signature   = base64.decode(base64Pad(parts[2]))
+  var exp       = fromUnix(0)
+  if "exp" in payloadJson:
+    exp         = fromUnix(payloadJson["exp"].getInt())
+  let
+    header      = JwtHeader(json: headerJson)
+    payload     = JwtPayload(json: payloadJson, exp: exp)
+  return JwtToken(header: header, payload: payload,
+                  signature: signature, value: token)

--- a/nimutils/pubsub.nim
+++ b/nimutils/pubsub.nim
@@ -7,16 +7,29 @@
 ## multiplexing switchboard that is now part of the library.
 
 import tables, sugar, options, json, strutils, std/terminal, unicodeid,
-       rope_ansirender, rope_construct
+       rope_ansirender, rope_construct, std/httpclient
 
 type
-  InitCallback*   = ((SinkConfig) -> bool)
-  OutputCallback* = ((string, SinkConfig, Topic, StringTable) -> void)
-  CloseCallback*  = ((SinkConfig) -> bool)
-  FailCallback*   = ((SinkConfig, Topic, string, string, string) -> void)
-  LogCallback*    = ((SinkConfig, Topic, string) -> void)
-  StringTable*    = OrderedTableRef[string, string]
-  MsgFilter*      = ((string, StringTable) -> (string, bool))
+  InitCallback*     = ((SinkConfig) -> bool)
+  OutputCallback*   = ((string, SinkConfig, Topic, StringTable) -> void)
+  CloseCallback*    = ((SinkConfig) -> bool)
+  FailCallback*     = ((SinkConfig, Topic, string, string, string) -> void)
+  LogCallback*      = ((SinkConfig, Topic, string) -> void)
+  ValidateCallback* = ((AuthConfig) -> void)
+  HeadersCallback*  = ((AuthConfig, HttpHeaders) -> HttpHeaders)
+  StringTable*      = OrderedTableRef[string, string]
+  MsgFilter*        = ((string, StringTable) -> (string, bool))
+
+  AuthImplementation* = ref object
+    name*:          string
+    keys*:          Table[string, bool]
+    validate*:      ValidateCallback
+    injectHeaders*: HeadersCallback
+
+  AuthConfig* = ref object
+    name*:           string
+    implementation*: AuthImplementation
+    params*:         StringTable
 
   SinkImplementation* = ref object
     name*:           string
@@ -33,8 +46,9 @@ type
     private*: RootRef        # It's funny to make 'private' public,
                              # but externally written sinks can store
                              # state here, like file pointers.
-    onFail*:   Option[FailCallback]
-    logFunc*:  Option[LogCallback]
+    onFail*:  Option[FailCallback]
+    logFunc*: Option[LogCallback]
+    auth*:    Option[AuthConfig]
     rmOnErr*: bool
 
   Topic* = ref object
@@ -45,8 +59,9 @@ proc getName*(sink: SinkImplementation): string = sink.name
 proc getName*(config: SinkConfig): string = config.name
 
 var allSinks:   Table[string, SinkImplementation]
+var allAuths:   Table[string, AuthImplementation]
 var allTopics*: Table[string, Topic]
-var revTopics: Table[Topic, string]
+var revTopics:  Table[Topic, string]
 
 proc subscribe*(topic: Topic, config: SinkConfig): Topic {.discardable.} =
   if config notin topic.subscribers:
@@ -67,13 +82,31 @@ proc registerSink*(name: string, sink: SinkImplementation) =
 proc getSinkImplementation*(name: string): Option[SinkImplementation] =
   if name in allSinks:
     return some(allSinks[name])
-
   return none(SinkImplementation)
+
+proc registerAuth*(name: string, auth: AuthImplementation) =
+  auth.name      = name
+  allAuths[name] = auth
+
+proc getAuthImplementation*(name: string): Option[AuthImplementation] =
+  if name in allAuths:
+    return some(allAuths[name])
+  return none(AuthImplementation)
 
 proc iolog*(s: SinkConfig, t: Topic, m: string) =
   if s.logFunc.isSome():
     let f = s.logFunc.get()
     f(s, t, m)
+
+proc ensureParamsHaveKeys(params: StringTable,
+                          keys: Table[string, bool]) =
+  for k, v in params:
+    if k notin keys:
+      raise newException(ValueError, "Extraneous key: " & k)
+
+  for k, v in keys:
+    if v and k notin params:
+      raise newException(ValueError, "Required key missing: " & k)
 
 proc configSink*(s:          SinkImplementation,
                  name:       string,
@@ -81,34 +114,23 @@ proc configSink*(s:          SinkImplementation,
                  filters:    seq[MsgFilter] = @[],
                  handler:    Option[FailCallback] = none(FailCallback),
                  logger:     Option[LogCallback]  = none(LogCallback),
+                 auth:       Option[AuthConfig]   = none(AuthConfig),
                  rmOnErr:    bool = true,
                  raiseOnErr: bool = false
-
                 ): Option[SinkConfig] =
-  var params: StringTable
+  let params = `params?`.get(newOrderedTable[string, string]())
 
-  if `params?`.isSome():
-    params = `params?`.get()
-  else:
-    params = newOrderedTable[string, string]()
-
-  for k, v in params:
-    if k notin s.keys:
-      if raiseOnErr:
-        raise newException(ValueError, "Extraneous key: " & k)
-      else:
-        return none(SinkConfig)
-
-  for k, v in s.keys:
-    if v and k notin params:
-      if raiseOnErr:
-        raise newException(ValueError, "Required key missing: " & k)
-      else:
-        return none(SinkConfig) # Required key missing.
+  try:
+    ensureParamsHaveKeys(params, s.keys)
+  except:
+    if raiseOnErr:
+      raise
+    else:
+      return none(SinkConfig)
 
   let confObj = SinkConfig(mySink: s, name: name, params: params,
                            logFunc: logger, filters: filters, onFail: handler,
-                           rmOnErr: rmOnErr)
+                           auth: auth, rmOnErr: rmOnErr)
 
   if s.initFunction.isSome():
     let fptr = s.initFunction.get()
@@ -119,6 +141,18 @@ proc configSink*(s:          SinkImplementation,
         return none(SinkConfig)
 
   return some(confObj)
+
+proc configAuth*(a: AuthImplementation,
+                 name: string,
+                 `params?`: Option[StringTable] = none(StringTable)
+                 ): Option[AuthConfig] =
+  let
+    params = `params?`.get(newOrderedTable[string, string]())
+    auth   = AuthConfig(name: name, implementation: a, params: params)
+  ensureParamsHaveKeys(params, a.keys)
+  if a.validate != nil:
+    a.validate(auth)
+  return some(auth)
 
 proc registerTopic*(name: string): Topic =
   if name in allTopics: return allTopics[name]


### PR DESCRIPTION
this will allow to add jwt auth type for the console sinks very easily and still be able to reuse them elsewhere in the codebase