### PR TITLE
using safeRequest in aws client + aws token support + sts client

### DIFF
--- a/nimutils/awsclient.nim
+++ b/nimutils/awsclient.nim
@@ -36,6 +36,56 @@ type
     key*: string
     key_expires*: Time
 
+  Arn* = object
+    partition*: string
+    service*:   string
+    region*:    string
+    account*:   string
+    resource*:  string
+
+  StsCallerIdentity* = object
+    arn*:     Arn
+    userId*:  string
+    account*: string
+
+proc `$`*(arn: Arn): string =
+  return @[
+    "arn",
+    arn.partition,
+    arn.service,
+    arn.region,
+    arn.account,
+    arn.resource,
+  ].join(":")
+
+template `or`(a, b: string): string =
+  if a != "":
+    a
+  else:
+    b
+
+proc with*(arn: Arn,
+           partition: string = "",
+           service:   string = "",
+           region:    string = "",
+           account:   string = "",
+           resource:  string = ""): Arn =
+  return Arn(partition: partition or arn.partition,
+             service:   service   or arn.service,
+             region:    region    or arn.region,
+             account:   account   or arn.account,
+             resource:  resource  or arn.resource)
+
+proc parseArn*(arn: string): Arn =
+  let parts = arn.split(":", maxsplit=6)
+  if len(parts) < 6:
+    raise newException(ValueError, "invalid arn")
+  return Arn(partition: parts[1],
+             service:   parts[2],
+             region:    parts[3],
+             account:   parts[4],
+             resource:  parts[5])
+
 const iso_8601_aws = "yyyyMMdd'T'HHmmss'Z'"
 
 proc getAmzDateString*(): string =

--- a/nimutils/rope_base.nim
+++ b/nimutils/rope_base.nim
@@ -340,9 +340,9 @@ proc search*(r: Rope,
       result.add(item)
     elif text.len() != 0 and item.kind == RopeAtom:
       for s in text:
-        echo "Searching for string of len ", s.len()
+        # echo "Searching for string of len ", s.len()
         if s in $(item.text):
-          echo "Got a hit: " & $(item.text)
+          # echo "Got a hit: " & $(item.text)
           result.add(item)
           break
     if result.len() == 1 and first:

--- a/nimutils/s3client.nim
+++ b/nimutils/s3client.nim
@@ -5,13 +5,15 @@
  ]#
 
 import strutils except toLower
-import times, unicode, tables, httpclient, xmlparser, xmltree, uri
+import times, unicode, tables, httpclient, xmlparser, xmltree, uri, std/[envvars]
 import awsclient
-
+export awsclient
 
 const
   awsURI = "https://amazonaws.com"
-  defRegion = "us-east-1"
+
+let
+  defRegion = getEnv("AWS_DEFAULT_REGION", "us-east-1")
 
 type
   S3Client* = object of AwsClient

--- a/nimutils/s3client.nim
+++ b/nimutils/s3client.nim
@@ -26,10 +26,9 @@ type
     etag*: string
     size*: int
 
-proc newS3Client*(credentials: (string, string), region: string = defRegion,
+proc newS3Client*(creds: AwsCredentials, region: string = defRegion,
     host: string = awsURI): S3Client =
   let
-    creds = AwsCredentials(credentials)
     # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
     httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ",
         "-").toLower&"; darwin/16.7.0")

--- a/nimutils/sigv4.nim
+++ b/nimutils/sigv4.nim
@@ -12,8 +12,9 @@ from uri import parseUri
 
 type
   AwsCredentials* = tuple
-    id: string
+    id:     string
     secret: string
+    token:  string
 
   AwsScope* = object
     date*: string
@@ -202,8 +203,10 @@ proc create_aws_authorization*(creds: AwsCredentials,
                               scope: AwsScope,
                               opts: (string, string) = (alg, term)): string =
 
-  result = create_signing_key(creds[1], scope, opts[1])
+  result = create_signing_key(creds.secret, scope, opts[1])
+  if creds.token != "":
+    headers["X-Amz-Security-Token"] = @[creds.token]
   # add AWS authorization header
   # http://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
-  headers["Authorization"] = @[create_aws_authorization(creds[0], result,
+  headers["Authorization"] = @[create_aws_authorization(creds.id, result,
       request, headers, scope, opts)]

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -1,5 +1,6 @@
 import httpclient, strutils, tables, times, uri, std/[envvars, json]
 import awsclient
+export awsclient
 
 const
   awsURI = "https://amazonaws.com"
@@ -9,56 +10,6 @@ let
 
 type
   StsClient* = object of AwsClient
-
-  Arn* = object
-    partition*: string
-    service*:   string
-    region*:    string
-    account*:   string
-    resource*:  string
-
-  StsCallerIdentity* = object
-    arn*:     Arn
-    userId*:  string
-    account*: string
-
-proc `$`*(arn: Arn): string =
-  return @[
-    "arn",
-    arn.partition,
-    arn.service,
-    arn.region,
-    arn.account,
-    arn.resource,
-  ].join(":")
-
-template `or`(a, b: string): string =
-  if a != "":
-    a
-  else:
-    b
-
-proc with*(arn: Arn,
-           partition: string = "",
-           service:   string = "",
-           region:    string = "",
-           account:   string = "",
-           resource:  string = ""): Arn =
-  return Arn(partition: partition or arn.partition,
-             service:   service   or arn.service,
-             region:    region    or arn.region,
-             account:   account   or arn.account,
-             resource:  resource  or arn.resource)
-
-proc parseArn*(arn: string): Arn =
-  let parts = arn.split(":", maxsplit=6)
-  if len(parts) < 6:
-    raise newException(ValueError, "invalid arn")
-  return Arn(partition: parts[1],
-             service:   parts[2],
-             region:    parts[3],
-             account:   parts[4],
-             resource:  parts[5])
 
 proc newStsClient*(creds: AwsCredentials,
                    region: string = defRegion,

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -1,4 +1,4 @@
-import httpclient, strutils, tables, times, uri, std/envvars
+import httpclient, strutils, tables, times, uri, std/[envvars, json]
 import awsclient
 
 const
@@ -9,6 +9,56 @@ let
 
 type
   StsClient* = object of AwsClient
+
+  Arn* = object
+    partition*: string
+    service*:   string
+    region*:    string
+    account*:   string
+    resource*:  string
+
+  StsCallerIdentity* = object
+    arn*:     Arn
+    userId*:  string
+    account*: string
+
+proc `$`*(arn: Arn): string =
+  return @[
+    "arn",
+    arn.partition,
+    arn.service,
+    arn.region,
+    arn.account,
+    arn.resource,
+  ].join(":")
+
+template `or`(a, b: string): string =
+  if a != "":
+    a
+  else:
+    b
+
+proc with*(arn: Arn,
+           partition: string = "",
+           service:   string = "",
+           region:    string = "",
+           account:   string = "",
+           resource:  string = ""): Arn =
+  return Arn(partition: partition or arn.partition,
+             service:   service   or arn.service,
+             region:    region    or arn.region,
+             account:   account   or arn.account,
+             resource:  resource  or arn.resource)
+
+proc parseArn*(arn: string): Arn =
+  let parts = arn.split(":", maxsplit=6)
+  if len(parts) < 6:
+    raise newException(ValueError, "invalid arn")
+  return Arn(partition: parts[1],
+             service:   parts[2],
+             region:    parts[3],
+             account:   parts[4],
+             resource:  parts[5])
 
 proc newStsClient*(creds: AwsCredentials,
                    region: string = defRegion,
@@ -34,12 +84,20 @@ proc newStsClient*(creds: AwsCredentials,
                    endpoint: endpoint, isAWS: endpoint.hostname == "amazonaws.com",
                    key: "", key_expires: getTime())
 
-proc getCallerIdentity*(self: var StsClient): Response =
+proc getCallerIdentity*(self: var StsClient): StsCallerIdentity =
   let params = {
     "action":  "POST",
     "payload": "Action=GetCallerIdentity&Version=2011-06-15",
   }.toTable
-  return self.request(params, newHttpHeaders(@[
+  let res = self.request(params, newHttpHeaders(@[
     ("Content-Type", "application/x-www-form-urlencoded"),
     ("Accept", "application/json"),
   ]))
+  if res.code != Http200:
+    raise newException(ValueError, res.status)
+  let
+    jsonResponse = parseJson(res.body())
+    identity     = jsonResponse["GetCallerIdentityResponse"]["GetCallerIdentityResult"]
+  return StsCallerIdentity(arn:     parseArn(identity["Arn"].getStr()),
+                           userId:  identity["UserId"].getStr(),
+                           account: identity["Account"].getStr())

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -1,0 +1,45 @@
+import httpclient, strutils, tables, times, uri, std/envvars
+import awsclient
+
+const
+  awsURI = "https://amazonaws.com"
+
+let
+  defRegion = getEnv("AWS_DEFAULT_REGION", "us-east-1")
+
+type
+  StsClient* = object of AwsClient
+
+proc newStsClient*(creds: AwsCredentials,
+                   region: string = defRegion,
+                   host: string = awsURI): StsClient =
+  let
+    # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
+    httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ", "-").toLower&"; darwin/16.7.0")
+    scope = AwsScope(date: getAmzDateString(), region: region, service: "sts")
+
+  var
+    endpoint: Uri
+    mhost = host
+
+  if mhost.len > 0:
+    if mhost.find("http") == -1:
+      echo "host should be a valid URI assuming http://"
+      mhost = "http://"&host
+  else:
+    mhost = awsURI
+  endpoint = parseUri(mhost)
+
+  return StsClient(httpClient: httpclient, credentials: creds, scope: scope,
+                   endpoint: endpoint, isAWS: endpoint.hostname == "amazonaws.com",
+                   key: "", key_expires: getTime())
+
+proc getCallerIdentity*(self: var StsClient): Response =
+  let params = {
+    "action":  "POST",
+    "payload": "Action=GetCallerIdentity&Version=2011-06-15",
+  }.toTable
+  return self.request(params, newHttpHeaders(@[
+    ("Content-Type", "application/x-www-form-urlencoded"),
+    ("Accept", "application/json"),
+  ]))


### PR DESCRIPTION
this PR:

* uses `safeRequest` for aws client communication which will guarantee timeout is honored like everywhere else
* adds support for aws session tokens which lambda roles use for example (needed for lambda metadata collection)
* adds aws sts client support for getting client identity (also needed for lambda)

I know long term we will want to shift to proper AWS library however this was simpler to adjust for the moment without figuring out how to use AWS C sdk.