### PR TITLE
bundling mozilla root CA store for when there are no default certs

### DIFF
--- a/nimutils/awsclient.nim
+++ b/nimutils/awsclient.nim
@@ -97,8 +97,9 @@ proc newAwsClient*(creds: AwsCredentials, region,
     service: string): AwsClient =
   let
     # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
-    httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ",
-        "-").toLower&"; darwin/16.7.0")
+    httpclient = createHttpClient(
+      userAgent = "nimaws-sdk/0.3.3; "&defUserAgent.replace(" ", "-").toLower&"; darwin/16.7.0",
+    )
     scope = AwsScope(date: getAmzDateString(), region: region, service: service)
 
   return AwsClient(httpClient: httpclient, credentials: creds, scope: scope,

--- a/nimutils/net.nim
+++ b/nimutils/net.nim
@@ -4,16 +4,11 @@ import ./managedtmp
 
 proc getRootCAStoreContent(): string =
   const
-    # stdlib times cannot generate times at compile-time
-    (today, exit) = gorgeEx("date -u +%Y-%m-%d")
-  if exit != 0:
-    raise newException(ValueError, "Cannot find todays date")
-  const
     caWiki  = "https://wiki.mozilla.org/CA/Included_Certificates"
     # link is taken directly from wiki page above
     # p.s. kind of odd its to salesforce vs one of mozilla-owned domains :shrug:
     caURL   = "https://ccadb.my.salesforce-sites.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites"
-    cache   = "mozilla-root-store-" & today # cache certs by day
+    cache   = "mozilla-root-store-" & CompileDate # cache certs by day
     curlCmd = "curl -fsSL --retry 5 " & caURL
     (contents, curlExitCode) = gorgeEx(curlCmd, cache=cache)
   if curlExitCode != 0:

--- a/nimutils/net.nim
+++ b/nimutils/net.nim
@@ -1,4 +1,43 @@
-import std/[asyncfutures, net, httpclient, uri, math, os]
+import std/[asyncfutures, net, httpclient, uri, math, os, streams, strutils]
+import openssl
+import ./managedtmp
+
+template getRootCAStoreContent(): string =
+  const
+    caWiki  = "https://wiki.mozilla.org/CA/Included_Certificates"
+    caURL   = "https://ccadb.my.salesforce-sites.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites"
+    curlCmd = "curl -fsSL --retry 5 " & caURL
+    (contents, curlExitCode) = gorgeEx(curlCmd, cache="mozilla-root-store")
+  if curlExitCode != 0:
+    raise newException(
+      ValueError,
+      "Could not downlaod CA root store: " & contents
+    )
+  const
+    opensslCmd             = "openssl storeutl -noout -certs /dev/stdin"
+    (check, checkExitCode) = gorgeEx(opensslCmd, input=contents)
+    checkLines             = check.splitLines()
+  if checkExitCode != 0:
+    raise newException(
+      ValueError,
+      "Could not validate CA root store certificates. " &
+      "Maybe server didnt return valid PEM file? " &
+      check
+    )
+  echo("Embedding Mozilla Root CA store with certificates " & checkLines[^1].toLower())
+  echo("For more information see " & caWiki)
+  contents
+
+var tmpCAStore = ""
+proc getCAStorePath(): string =
+  const contents = getRootCAStoreContent()
+  if tmpCAStore != "":
+    return tmpCAStore
+  let (stream, tmp) = getNewTempFile("cabundle", ".pem")
+  stream.write(contents)
+  stream.close()
+  tmpCAStore = tmp
+  return tmp
 
 {.emit: """
 #include <stdlib.h>
@@ -8,7 +47,6 @@ import std/[asyncfutures, net, httpclient, uri, math, os]
 #include <unistd.h>
 
 #include <stdio.h>
-
 
 // Cloudflare DNS
 const char * dummy_dst  = "1.1.1.1";
@@ -118,3 +156,75 @@ proc safeRequest*(client: HttpClient,
   withRetry(retries, firstRetryDelayMs):
     return client.request(url = url, httpMethod = httpMethod, body = body,
                           headers = headers, multipart = multipart)
+
+# https://github.com/nim-lang/Nim/blob/a45f43da3407dbbf8ecd15ce8ecb361af677add7/lib/pure/httpclient.nim#L380-L386
+# similar to stdlib but defaults to bundled CAs
+proc getSSLContext(caFile: string = ""): SslContext =
+  if caFile != "":
+    # note when caFile is provided there is no try..except
+    # otherwise we would silently fail to bundled CA root store
+    # if caFile is invalid/does not exist
+    return newContext(verifyMode = CVerifyPeer, caFile = caFile)
+  else:
+    try:
+      return newContext(verifyMode = CVerifyPeer)
+    except:
+      return newContext(verifyMode = CVerifyPeer, caFile = getCAStorePath())
+
+proc createHttpClient*(uri: Uri = parseUri(""),
+                       maxRedirects: int = 3,
+                       timeout: int = 1000, # in ms - 1 second
+                       pinnedCert: string = "",
+                       disallowHttp: bool = false,
+                       userAgent: string = defUserAgent,
+                       ): HttpClient =
+  var context: SslContext
+
+  if uri.scheme in @["", "https"]:
+    context = getSSLContext(caFile = pinnedCert)
+  else:
+    if disallowHttp:
+      raise newException(ValueError, "http:// URLs not allowed (only https).")
+    elif pinnedCert != "":
+      raise newException(ValueError, "Pinned cert not allowed with http " &
+                                     "URL (only https).")
+
+  let client = newHttpClient(sslContext   = context,
+                             userAgent    = userAgent,
+                             timeout      = timeout,
+                             maxRedirects = maxRedirects)
+
+  if client == nil:
+    raise newException(ValueError, "Invalid HTTP configuration")
+
+  return client
+
+proc safeRequest*(url: Uri | string,
+                  httpMethod: HttpMethod | string = HttpGet,
+                  body = "",
+                  headers: HttpHeaders = nil,
+                  multipart: MultipartData = nil,
+                  retries: int = 0,
+                  firstRetryDelayMs: int = 0,
+                  timeout: int = 1000,
+                  pinnedCert: string = "",
+                  maxRedirects: int = 3,
+                  disallowHttp: bool = false,
+                  ): Response =
+  var uri: Uri
+  when url is string:
+    uri = parseUri(url)
+  else:
+    uri = url
+  let client = createHttpClient(uri           = uri,
+                                maxRedirects  = maxRedirects,
+                                timeout       = timeout,
+                                pinnedCert    = pinnedCert,
+                                disallowHttp  = disallowHttp)
+  return client.safeRequest(url               = uri,
+                            httpMethod        = httpMethod,
+                            body              = body,
+                            headers           = headers,
+                            multipart         = multipart,
+                            retries           = retries,
+                            firstRetryDelayMs = firstRetryDelayMs)


### PR DESCRIPTION
not all machines have system certs such as in busybox containers and so by bundling certs from Mozilla we can fallback to them when system certs are missing