### PR TITLE
fixing hanging stdin read in the switchboard

### DIFF
--- a/nimutils/c/subproc.c
+++ b/nimutils/c/subproc.c
@@ -55,7 +55,7 @@ bool
 subproc_set_envp(subprocess_t *ctx, char *envp[])
 {
     if (ctx->run) {
-	return false;
+        return false;
     }
 
     ctx->envp = envp;
@@ -74,26 +74,26 @@ bool
 subproc_pass_to_stdin(subprocess_t *ctx, char *str, size_t len, bool close_fd)
 {
     if (ctx->str_waiting || ctx->sb.done) {
-	return false;
+        return false;
     }
 
     if (ctx->run && close_fd) {
-	return false;
+        return false;
     }
 
     sb_init_party_input_buf(&ctx->sb, &ctx->str_stdin, str, len, true, true,
-			    close_fd);
+    close_fd);
 
     if (ctx->run) {
-	return sb_route(&ctx->sb, &ctx->str_stdin, &ctx->subproc_stdin);
+        return sb_route(&ctx->sb, &ctx->str_stdin, &ctx->subproc_stdin);
     } else {
-	ctx->str_waiting = true;
+        ctx->str_waiting = true;
 
-	if (close_fd) {
-	    ctx->pty_stdin_pipe = true;
-	}
+        if (close_fd) {
+            ctx->pty_stdin_pipe = true;
+        }
 
-	return true;
+        return true;
     }
 }
 
@@ -117,7 +117,7 @@ bool
 subproc_set_passthrough(subprocess_t *ctx, unsigned char which, bool combine)
 {
     if (ctx->run || which > SP_IO_ALL) {
-	return false;
+        return false;
     }
 
     ctx->passthrough      = which;
@@ -148,7 +148,7 @@ bool
 subproc_set_capture(subprocess_t *ctx, unsigned char which, bool combine)
 {
     if (ctx->run || which > SP_IO_ALL) {
-	return false;
+        return false;
     }
 
     ctx->capture          = which;
@@ -159,10 +159,10 @@ subproc_set_capture(subprocess_t *ctx, unsigned char which, bool combine)
 
 bool
 subproc_set_io_callback(subprocess_t *ctx, unsigned char which,
-			switchboard_cb_t cb)
+                        switchboard_cb_t cb)
 {
     if (ctx->run || which > SP_IO_ALL) {
-	return false;
+        return false;
     }
 
     deferred_cb_t *cbinfo = (deferred_cb_t *)malloc(sizeof(deferred_cb_t));
@@ -213,7 +213,7 @@ bool
 subproc_use_pty(subprocess_t *ctx)
 {
     if (ctx->run) {
-	return false;
+        return false;
     }
     ctx->use_pty = true;
     return true;
@@ -244,18 +244,18 @@ pause_passthrough(subprocess_t *ctx, unsigned char which)
      */
 
     if (which & SP_IO_STDIN) {
-	if (ctx->pty_fd) {
-	    sb_pause_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdout);
-	} else {
-	    sb_pause_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdin);
-	}
+        if (ctx->pty_fd) {
+            sb_pause_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdout);
+        } else {
+            sb_pause_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdin);
+        }
     }
     if (which & SP_IO_STDOUT) {
-	sb_pause_route(&ctx->sb, &ctx->subproc_stdout, &ctx->parent_stdout);
+        sb_pause_route(&ctx->sb, &ctx->subproc_stdout, &ctx->parent_stdout);
     }
     if (!ctx->pty_fd && (which & SP_IO_STDERR)) {
-	sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stdout);
-	sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stderr);
+        sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stdout);
+        sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stderr);
     }
 }
 
@@ -272,18 +272,18 @@ resume_passthrough(subprocess_t *ctx, unsigned char which)
      */
 
     if (which & SP_IO_STDIN) {
-	if (ctx->pty_fd) {
-	    sb_resume_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdout);
-	} else {
-	    sb_resume_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdin);
-	}
+        if (ctx->pty_fd) {
+            sb_resume_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdout);
+        } else {
+            sb_resume_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdin);
+        }
     }
     if (which & SP_IO_STDOUT) {
-	sb_resume_route(&ctx->sb, &ctx->subproc_stdout, &ctx->parent_stdout);
+        sb_resume_route(&ctx->sb, &ctx->subproc_stdout, &ctx->parent_stdout);
     }
     if (!ctx->pty_fd && (which & SP_IO_STDERR)) {
-	sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stdout);
-	sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stderr);
+        sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stdout);
+        sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->parent_stderr);
     }
 }
 
@@ -291,16 +291,16 @@ void
 pause_capture(subprocess_t *ctx, unsigned char which)
 {
     if (which & SP_IO_STDIN) {
-	sb_pause_route(&ctx->sb, &ctx->parent_stdin, &ctx->capture_stdin);
+        sb_pause_route(&ctx->sb, &ctx->parent_stdin, &ctx->capture_stdin);
     }
 
     if (which & SP_IO_STDOUT) {
-	sb_pause_route(&ctx->sb, &ctx->subproc_stdout, &ctx->capture_stdout);
+        sb_pause_route(&ctx->sb, &ctx->subproc_stdout, &ctx->capture_stdout);
     }
 
     if ((which & SP_IO_STDERR) && !ctx->pty_fd) {
-	sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stdout);
-	sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stderr);
+        sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stdout);
+        sb_pause_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stderr);
     }
 }
 
@@ -308,16 +308,16 @@ void
 resume_capture(subprocess_t *ctx, unsigned char which)
 {
     if (which & SP_IO_STDIN) {
-	sb_resume_route(&ctx->sb, &ctx->parent_stdin, &ctx->capture_stdin);
+        sb_resume_route(&ctx->sb, &ctx->parent_stdin, &ctx->capture_stdin);
     }
 
     if (which & SP_IO_STDOUT) {
-	sb_resume_route(&ctx->sb, &ctx->subproc_stdout, &ctx->capture_stdout);
+        sb_resume_route(&ctx->sb, &ctx->subproc_stdout, &ctx->capture_stdout);
     }
 
     if ((which & SP_IO_STDERR) && !ctx->pty_fd) {
-	sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stdout);
-	sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stderr);
+        sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stdout);
+        sb_resume_route(&ctx->sb, &ctx->subproc_stderr, &ctx->capture_stderr);
     }
 }
 
@@ -327,70 +327,72 @@ setup_subscriptions(subprocess_t *ctx, bool pty)
     party_t *stderr_dst = &ctx->parent_stderr;
 
     if (ctx->pt_all_to_stdout) {
-	stderr_dst = &ctx->parent_stdout;
+        stderr_dst = &ctx->parent_stdout;
     }
 
     if (ctx->passthrough) {
-	if (ctx->passthrough & SP_IO_STDIN) {
-	    if (pty) {
-		sb_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdout);
-	    }
-	    else {
-		sb_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdin);
-	    }
-	}
-	if (ctx->passthrough & SP_IO_STDOUT) {
-	    sb_route(&ctx->sb, &ctx->subproc_stdout, &ctx->parent_stdout);
-	}
-	if (!pty && ctx->passthrough & SP_IO_STDERR) {
-	    sb_route(&ctx->sb, &ctx->subproc_stderr, stderr_dst);
-	}
+        if (ctx->passthrough & SP_IO_STDIN) {
+            if (pty) {
+                // in pty, ctx->subproc_stdout is the same FD used for stdin
+                // as its the same r/w FD for both
+                sb_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdout);
+            }
+            else {
+                sb_route(&ctx->sb, &ctx->parent_stdin, &ctx->subproc_stdin);
+            }
+        }
+        if (ctx->passthrough & SP_IO_STDOUT) {
+            sb_route(&ctx->sb, &ctx->subproc_stdout, &ctx->parent_stdout);
+        }
+        if (!pty && ctx->passthrough & SP_IO_STDERR) {
+            sb_route(&ctx->sb, &ctx->subproc_stderr, stderr_dst);
+        }
     }
 
     if (ctx->capture) {
-	if (ctx->capture & SP_IO_STDIN) {
-	    sb_init_party_output_buf(&ctx->sb, &ctx->capture_stdin,
-				  "stdin",  CAP_ALLOC);
-	}
-	if (ctx->capture & SP_IO_STDOUT) {
-	    sb_init_party_output_buf(&ctx->sb, &ctx->capture_stdout,
-				  "stdout", CAP_ALLOC);
-	}
+        if (ctx->capture & SP_IO_STDIN) {
+            sb_init_party_output_buf(&ctx->sb, &ctx->capture_stdin,
+                                     "stdin",  CAP_ALLOC);
+        }
+        if (ctx->capture & SP_IO_STDOUT) {
+            sb_init_party_output_buf(&ctx->sb, &ctx->capture_stdout,
+                                     "stdout", CAP_ALLOC);
+        }
 
-	if (ctx->combine_captures) {
-	    if (!(ctx->capture & SP_IO_STDOUT) &&
-		ctx->capture & SP_IO_STDERR) {
-		if (ctx->capture & SP_IO_STDOUT) {
-		    sb_init_party_output_buf(&ctx->sb, &ctx->capture_stdout,
-					  "stdout", CAP_ALLOC);
-		}
-      	    }
+        if (ctx->combine_captures) {
+            if (!(ctx->capture & SP_IO_STDOUT) &&
+                ctx->capture & SP_IO_STDERR) {
+                if (ctx->capture & SP_IO_STDOUT) {
+                    sb_init_party_output_buf(&ctx->sb, &ctx->capture_stdout,
+                                             "stdout", CAP_ALLOC);
+                }
+            }
 
-	    stderr_dst = &ctx->capture_stdout;
-	}
-	else {
-	    if (!pty && ctx->capture & SP_IO_STDERR) {
-		sb_init_party_output_buf(&ctx->sb, &ctx->capture_stderr,
-				      "stderr", CAP_ALLOC);
-	    }
+            stderr_dst = &ctx->capture_stdout;
+        }
+        else {
+            if (!pty && ctx->capture & SP_IO_STDERR) {
+                sb_init_party_output_buf(&ctx->sb, &ctx->capture_stderr,
+                                         "stderr", CAP_ALLOC);
+            }
 
-	    stderr_dst = &ctx->capture_stderr;
-	}
+            stderr_dst = &ctx->capture_stderr;
+        }
 
-	if (ctx->capture & SP_IO_STDIN) {
-	    sb_route(&ctx->sb, &ctx->parent_stdin, &ctx->capture_stdin);
-	}
-	if (ctx->capture & SP_IO_STDOUT) {
-	    sb_route(&ctx->sb, &ctx->subproc_stdout, &ctx->capture_stdout);
-	}
-	if (!pty && ctx->capture & SP_IO_STDERR) {
-	    sb_route(&ctx->sb, &ctx->subproc_stderr, stderr_dst);
-	}
+        if (ctx->capture & SP_IO_STDIN) {
+            sb_route(&ctx->sb, &ctx->parent_stdin, &ctx->capture_stdin);
+        }
+        if (ctx->capture & SP_IO_STDOUT) {
+            sb_route(&ctx->sb, &ctx->subproc_stdout, &ctx->capture_stdout);
+        }
+        if (!pty && ctx->capture & SP_IO_STDERR) {
+            sb_route(&ctx->sb, &ctx->subproc_stderr, stderr_dst);
+        }
     }
 
     if (ctx->str_waiting) {
-	sb_route(&ctx->sb, &ctx->str_stdin, &ctx->subproc_stdin);
-	ctx->str_waiting = false;
+        sb_route(&ctx->sb, &ctx->str_stdin, &ctx->subproc_stdin);
+        ctx->str_waiting = false;
     }
 
     // Make sure calls to the API know we've started!
@@ -401,10 +403,10 @@ static void
 subproc_do_exec(subprocess_t *ctx)
 {
     if (ctx->envp) {
-	execve(ctx->cmd, ctx->argv, ctx->envp);
+        execve(ctx->cmd, ctx->argv, ctx->envp);
     }
     else {
-	execv(ctx->cmd, ctx->argv);
+        execv(ctx->cmd, ctx->argv);
     }
     // If we get past the exec, kill the subproc, which will
     // tear down the switchboard.
@@ -427,17 +429,17 @@ subproc_install_callbacks(subprocess_t *ctx)
     deferred_cb_t *entry = ctx->deferred_cbs;
 
     while(entry) {
-	entry->to_free = subproc_new_party_callback(&ctx->sb, entry->cb);
-	if (entry->which & SP_IO_STDIN) {
-	    sb_route(&ctx->sb, &ctx->parent_stdin, entry->to_free);
-	}
-	if (entry->which & SP_IO_STDOUT) {
-	    sb_route(&ctx->sb, &ctx->subproc_stdout, entry->to_free);
-	}
-	if (entry->which & SP_IO_STDERR) {
-	    sb_route(&ctx->sb, &ctx->subproc_stderr, entry->to_free);
-	}
-	entry = entry->next;
+        entry->to_free = subproc_new_party_callback(&ctx->sb, entry->cb);
+        if (entry->which & SP_IO_STDIN) {
+            sb_route(&ctx->sb, &ctx->parent_stdin, entry->to_free);
+        }
+        if (entry->which & SP_IO_STDOUT) {
+            sb_route(&ctx->sb, &ctx->subproc_stdout, entry->to_free);
+        }
+        if (entry->which & SP_IO_STDERR) {
+            sb_route(&ctx->sb, &ctx->subproc_stderr, entry->to_free);
+        }
+        entry = entry->next;
     }
 }
 
@@ -445,7 +447,7 @@ static void
 run_startup_callback(subprocess_t *ctx)
 {
     if (ctx->startup_callback) {
-	(*ctx->startup_callback)(ctx);
+        (*ctx->startup_callback)(ctx);
     }
 }
 
@@ -464,31 +466,31 @@ subproc_spawn_fork(subprocess_t *ctx)
     pid = fork();
 
     if (pid != 0) {
-	close(stdin_pipe[0]);
-	close(stdout_pipe[1]);
-	close(stderr_pipe[1]);
+        close(stdin_pipe[0]);
+        close(stdout_pipe[1]);
+        close(stderr_pipe[1]);
 
-	sb_init_party_fd(&ctx->sb, &ctx->subproc_stdin, stdin_pipe[1],
-			 O_WRONLY, false, true);
-	sb_init_party_fd(&ctx->sb, &ctx->subproc_stdout, stdout_pipe[0],
-			 O_RDONLY, false, true);
-	sb_init_party_fd(&ctx->sb, &ctx->subproc_stderr, stderr_pipe[0],
-			 O_RDONLY, false, true);
+        sb_init_party_fd(&ctx->sb, &ctx->subproc_stdin, stdin_pipe[1],
+                         O_WRONLY, false, true);
+        sb_init_party_fd(&ctx->sb, &ctx->subproc_stdout, stdout_pipe[0],
+                         O_RDONLY, false, true);
+        sb_init_party_fd(&ctx->sb, &ctx->subproc_stderr, stderr_pipe[0],
+                         O_RDONLY, false, true);
 
-	sb_monitor_pid(&ctx->sb, pid, &ctx->subproc_stdin, &ctx->subproc_stdout,
-		    &ctx->subproc_stderr, true);
-	subproc_install_callbacks(ctx);
-	setup_subscriptions(ctx, false);
-	run_startup_callback(ctx);
+        sb_monitor_pid(&ctx->sb, pid, &ctx->subproc_stdin, &ctx->subproc_stdout,
+                       &ctx->subproc_stderr, true);
+        subproc_install_callbacks(ctx);
+        setup_subscriptions(ctx, false);
+        run_startup_callback(ctx);
     } else {
-	close(stdin_pipe[1]);
-	close(stdout_pipe[0]);
-	close(stderr_pipe[0]);
-	dup2(stdin_pipe[0],  0);
-	dup2(stdout_pipe[1], 1);
-	dup2(stderr_pipe[1], 2);
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        close(stderr_pipe[0]);
+        dup2(stdin_pipe[0],  0);
+        dup2(stdout_pipe[1], 1);
+        dup2(stderr_pipe[1], 2);
 
-	subproc_do_exec(ctx);
+        subproc_do_exec(ctx);
     }
 }
 
@@ -517,7 +519,7 @@ subproc_spawn_forkpty(subprocess_t *ctx)
     tcgetattr(0, &ctx->saved_termcap);
 
     if (ctx->pty_stdin_pipe) {
-	pipe(stdin_pipe);
+        pipe(stdin_pipe);
     }
 
     // We're going to use a pipe for stderr to get a separate
@@ -530,68 +532,68 @@ subproc_spawn_forkpty(subprocess_t *ctx)
     // Note that this means the child process will see isatty() return
     // true for stdin and stdout, but not stderr.
     if(!isatty(0)) {
-	win_ptr  = NULL;
+        win_ptr  = NULL;
     } else {
-	ioctl(0, TIOCGWINSZ, win_ptr);
+        ioctl(0, TIOCGWINSZ, win_ptr);
     }
 
     pid = forkpty(&pty_fd, NULL, term_ptr, win_ptr);
 
     if (pid != 0) {
-	if (ctx->pty_stdin_pipe) {
-	    close(stdin_pipe[0]);
-	    sb_init_party_fd(&ctx->sb, &ctx->subproc_stdin, stdin_pipe[1],
-			     O_WRONLY, false, true);
-	}
+        if (ctx->pty_stdin_pipe) {
+            close(stdin_pipe[0]);
+            sb_init_party_fd(&ctx->sb, &ctx->subproc_stdin, stdin_pipe[1],
+                             O_WRONLY, false, true);
+        }
 
-	ctx->pty_fd = pty_fd;
+        ctx->pty_fd = pty_fd;
 
-	sb_init_party_fd(&ctx->sb, &ctx->subproc_stdout, pty_fd, O_RDWR, true,
-			 true);
+        sb_init_party_fd(&ctx->sb, &ctx->subproc_stdout,
+                         pty_fd, O_RDWR, true, true);
 
-	sb_monitor_pid(&ctx->sb, pid, &ctx->subproc_stdout,
-		       &ctx->subproc_stdout, NULL, true);
-	subproc_install_callbacks(ctx);
-	setup_subscriptions(ctx, true);
+        sb_monitor_pid(&ctx->sb, pid, &ctx->subproc_stdout,
+                       &ctx->subproc_stdout, NULL, true);
+        subproc_install_callbacks(ctx);
+        setup_subscriptions(ctx, true);
 
-	if (!ctx->parent_termcap) {
-	    termcap_set_raw_mode(&ctx->saved_termcap);
-	}
-	else {
-	    tcsetattr(1, TCSAFLUSH, ctx->parent_termcap);
-	}
-	int flags = fcntl(pty_fd, F_GETFL, 0) | O_NONBLOCK;
-	fcntl(pty_fd, F_SETFL, flags);
-	run_startup_callback(ctx);
+        if (!ctx->parent_termcap) {
+            termcap_set_raw_mode(&ctx->saved_termcap);
+        }
+        else {
+            tcsetattr(1, TCSAFLUSH, ctx->parent_termcap);
+        }
+        int flags = fcntl(pty_fd, F_GETFL, 0) | O_NONBLOCK;
+        fcntl(pty_fd, F_SETFL, flags);
+        run_startup_callback(ctx);
 
     } else {
 
-	setvbuf(stdout, NULL, _IONBF, (size_t) 0);
-	setvbuf(stdin, NULL, _IONBF, (size_t) 0);
+        setvbuf(stdout, NULL, _IONBF, (size_t) 0);
+        setvbuf(stdin, NULL, _IONBF, (size_t) 0);
 
-	if (ctx->pty_stdin_pipe) {
-	    close(stdin_pipe[1]);
-	    dup2(stdin_pipe[0], 0);
-	}
+        if (ctx->pty_stdin_pipe) {
+            close(stdin_pipe[1]);
+            dup2(stdin_pipe[0], 0);
+        }
 
-	signal(SIGHUP,   SIG_DFL);
-	signal(SIGINT,   SIG_DFL);
-	signal(SIGILL,   SIG_DFL);
-	signal(SIGABRT,  SIG_DFL);
-	signal(SIGFPE,   SIG_DFL);
-	signal(SIGKILL,  SIG_DFL);
-	signal(SIGSEGV,  SIG_DFL);
-	signal(SIGPIPE,  SIG_DFL);
-	signal(SIGALRM,  SIG_DFL);
-	signal(SIGTERM,  SIG_DFL);
-	signal(SIGCHLD,  SIG_DFL);
-	signal(SIGCONT,  SIG_DFL);
-	signal(SIGSTOP,  SIG_DFL);
-	signal(SIGTSTP,  SIG_DFL);
-	signal(SIGTTIN,  SIG_DFL);
-	signal(SIGTTOU,  SIG_DFL);
-	signal(SIGWINCH, SIG_DFL);
-	subproc_do_exec(ctx);
+        signal(SIGHUP,   SIG_DFL);
+        signal(SIGINT,   SIG_DFL);
+        signal(SIGILL,   SIG_DFL);
+        signal(SIGABRT,  SIG_DFL);
+        signal(SIGFPE,   SIG_DFL);
+        signal(SIGKILL,  SIG_DFL);
+        signal(SIGSEGV,  SIG_DFL);
+        signal(SIGPIPE,  SIG_DFL);
+        signal(SIGALRM,  SIG_DFL);
+        signal(SIGTERM,  SIG_DFL);
+        signal(SIGCHLD,  SIG_DFL);
+        signal(SIGCONT,  SIG_DFL);
+        signal(SIGSTOP,  SIG_DFL);
+        signal(SIGTSTP,  SIG_DFL);
+        signal(SIGTTIN,  SIG_DFL);
+        signal(SIGTTOU,  SIG_DFL);
+        signal(SIGWINCH, SIG_DFL);
+        subproc_do_exec(ctx);
     }
 }
 
@@ -616,10 +618,10 @@ void
 subproc_start(subprocess_t *ctx)
 {
     if (ctx->use_pty) {
-	subproc_spawn_forkpty(ctx);
+        subproc_spawn_forkpty(ctx);
     }
     else {
-	subproc_spawn_fork(ctx);
+        subproc_spawn_fork(ctx);
     }
 }
 
@@ -676,10 +678,10 @@ subproc_close(subprocess_t *ctx)
     deferred_cb_t *next;
 
     while (cbs) {
-	next = cbs->next;
-	free(cbs->to_free);
-	free(cbs);
-	cbs = next;
+        next = cbs->next;
+        free(cbs->to_free);
+        free(cbs);
+        cbs = next;
     }
 }
 
@@ -693,7 +695,7 @@ subproc_get_pid(subprocess_t *ctx)
     monitor_t *subproc = ctx->sb.pid_watch_list;
 
     if (!subproc) {
-	return -1;
+        return -1;
     }
     return subproc->pid;
 }
@@ -710,10 +712,10 @@ char *
 sp_result_capture(sp_result_t *ctx, char *tag, size_t *outlen)
 {
     for (int i = 0; i < ctx->num_captures; i++) {
-	if (!strcmp(tag, ctx->captures[i].tag)) {
-	    *outlen = ctx->captures[i].len;
-	    return ctx->captures[i].contents;
-	}
+        if (!strcmp(tag, ctx->captures[i].tag)) {
+            *outlen = ctx->captures[i].len;
+            return ctx->captures[i].contents;
+        }
     }
 
     *outlen = 0;
@@ -733,7 +735,7 @@ subproc_get_exit(subprocess_t *ctx, bool wait_for_exit)
     monitor_t *subproc = ctx->sb.pid_watch_list;
 
     if (!subproc) {
-	return -1;
+        return -1;
     }
 
     process_status_check(subproc, wait_for_exit);
@@ -746,7 +748,7 @@ subproc_get_errno(subprocess_t *ctx, bool wait_for_exit)
     monitor_t *subproc = ctx->sb.pid_watch_list;
 
     if (!subproc) {
-	return -1;
+        return -1;
     }
 
     process_status_check(subproc, wait_for_exit);
@@ -759,7 +761,7 @@ subproc_get_signal(subprocess_t *ctx, bool wait_for_exit)
     monitor_t *subproc = ctx->sb.pid_watch_list;
 
     if (!subproc) {
-	return -1;
+        return -1;
     }
 
     process_status_check(subproc, wait_for_exit);
@@ -816,14 +818,14 @@ test1() {
     result = subproc_run(&ctx);
 
     while(result) {
-	if (result->tag) {
-	    print_hex(result->contents, result->content_len, result->tag);
-	}
-	else {
-	    printf("PID: %d\n", result->pid);
-	    printf("Exit status: %d\n", result->exit_status);
-	}
-	result = result->next;
+        if (result->tag) {
+            print_hex(result->contents, result->content_len, result->tag);
+        }
+        else {
+            printf("PID: %d\n", result->pid);
+            printf("Exit status: %d\n", result->exit_status);
+        }
+        result = result->next;
     }
     return 0;
 }
@@ -847,14 +849,14 @@ test2() {
     result = subproc_run(&ctx);
 
     while(result) {
-	if (result->tag) {
-	    print_hex(result->contents, result->content_len, result->tag);
-	}
-	else {
-	    printf("PID: %d\n", result->pid);
-	    printf("Exit status: %d\n", result->exit_status);
-	}
-	result = result->next;
+        if (result->tag) {
+            print_hex(result->contents, result->content_len, result->tag);
+        }
+        else {
+            printf("PID: %d\n", result->pid);
+            printf("Exit status: %d\n", result->exit_status);
+        }
+        result = result->next;
     }
     return 0;
 }
@@ -877,14 +879,14 @@ test3() {
     result = subproc_run(&ctx);
 
     while(result) {
-	if (result->tag) {
-	    print_hex(result->contents, result->content_len, result->tag);
-	}
-	else {
-	    printf("PID: %d\n", result->pid);
-	    printf("Exit status: %d\n", result->exit_status);
-	}
-	result = result->next;
+        if (result->tag) {
+            print_hex(result->contents, result->content_len, result->tag);
+        }
+        else {
+            printf("PID: %d\n", result->pid);
+            printf("Exit status: %d\n", result->exit_status);
+        }
+        result = result->next;
     }
     return 0;
 }
@@ -908,14 +910,14 @@ test4() {
     result = subproc_run(&ctx);
 
     while(result) {
-	if (result->tag) {
-	    print_hex(result->contents, result->content_len, result->tag);
-	}
-	else {
-	    printf("PID: %d\n", result->pid);
-	    printf("Exit status: %d\n", result->exit_status);
-	}
-	result = result->next;
+        if (result->tag) {
+            print_hex(result->contents, result->content_len, result->tag);
+        }
+        else {
+            printf("PID: %d\n", result->pid);
+            printf("Exit status: %d\n", result->exit_status);
+        }
+        result = result->next;
     }
     return 0;
 }

--- a/nimutils/c/switchboard.c
+++ b/nimutils/c/switchboard.c
@@ -37,15 +37,15 @@ read_one(int fd, char *buf, size_t nbytes)
     ssize_t  n;
 
     while (true) {
-	n = read(fd, buf, nbytes);
+        n = read(fd, buf, nbytes);
 
-	if (n == -1) {
-	    if (errno == EINTR || errno == EAGAIN) {
-		continue;
-	    }
-	}
+        if (n == -1) {
+            if (errno == EINTR || errno == EAGAIN) {
+                continue;
+            }
+        }
 
-	return n;
+        return n;
     }
 }
 
@@ -75,7 +75,7 @@ static inline void
 register_fd(switchboard_t *ctx, int fd)
 {
     if (ctx->max_fd <= fd) {
-	ctx->max_fd = fd + 1;
+        ctx->max_fd = fd + 1;
     }
 }
 
@@ -83,10 +83,10 @@ int
 party_fd(party_t *party)
 {
     if (party->party_type == PT_FD) {
-	return party->info.fdinfo.fd;
+        return party->info.fdinfo.fd;
     }
     else {
-	return party->info.listenerinfo.fd;
+        return party->info.listenerinfo.fd;
     }
 }
 
@@ -165,8 +165,8 @@ register_loner(switchboard_t *ctx, party_t *loner)
  */
 void
 sb_init_party_listener(switchboard_t *ctx, party_t *party, int sockfd,
-		       accept_cb_t callback, bool stop_when_closed,
-		       bool close_on_destroy)
+                       accept_cb_t callback, bool stop_when_closed,
+                       bool close_on_destroy)
 {
     /* Stop on close should really only be applied to stdin/out/err,
      * and socket FDs. For subprocesses, add the flag when registering
@@ -187,18 +187,18 @@ sb_init_party_listener(switchboard_t *ctx, party_t *party, int sockfd,
     register_read_fd(ctx, party);
 
     if (stop_when_closed) {
-	party->stop_on_close = true;
+        party->stop_on_close = true;
     }
 }
 
 // allocate and call sb_init_party_listener.
 party_t *
 sb_new_party_listener(switchboard_t *ctx, int sockfd, accept_cb_t callback,
-		   bool stop_when_closed, bool close_on_destroy)
+                      bool stop_when_closed, bool close_on_destroy)
 {
     party_t *result = (party_t *)calloc(sizeof(party_t), 1);
     sb_init_party_listener(ctx, result, sockfd, callback, stop_when_closed,
-			   close_on_destroy);
+                           close_on_destroy);
 
     return result;
 }
@@ -218,7 +218,7 @@ sb_new_party_listener(switchboard_t *ctx, int sockfd, accept_cb_t callback,
  */
 void
 sb_init_party_fd(switchboard_t *ctx, party_t *party, int fd, int perms,
-	      bool stop_when_closed, bool close_on_destroy)
+                 bool stop_when_closed, bool close_on_destroy)
 {
     memset(party, 0, sizeof(party_t));
 
@@ -234,28 +234,28 @@ sb_init_party_fd(switchboard_t *ctx, party_t *party, int fd, int perms,
     fd_obj->fd                   = fd;
 
     if (perms != O_WRONLY) {
-	party->open_for_read    = true;
-	party->can_read_from_it = true;
-	register_read_fd(ctx, party);
+        party->open_for_read    = true;
+        party->can_read_from_it = true;
+        register_read_fd(ctx, party);
 
     }
     if (perms != O_RDONLY) {
-	party->open_for_write  = true;
-	party->can_write_to_it = true;
-	register_writer_fd(ctx, party);
+        party->open_for_write  = true;
+        party->can_write_to_it = true;
+        register_writer_fd(ctx, party);
     }
     if (stop_when_closed) {
-	party->stop_on_close = true;
+        party->stop_on_close = true;
     }
 }
 
 party_t *
 sb_new_party_fd(switchboard_t *ctx, int fd, int perms,
-		   bool stop_when_closed, bool close_on_destroy)
+                bool stop_when_closed, bool close_on_destroy)
 {
     party_t *result = (party_t *)calloc(sizeof(party_t), 1);
     sb_init_party_fd(ctx, result, fd, perms, stop_when_closed,
-		     close_on_destroy);
+                     close_on_destroy);
 
     return result;
 }
@@ -268,14 +268,14 @@ sb_new_party_fd(switchboard_t *ctx, int fd, int perms,
  */
 void
 sb_init_party_input_buf(switchboard_t *ctx, party_t *party, char *input,
-		size_t len, bool dup, bool free, bool close_fd_when_done)
+                        size_t len, bool dup, bool free, bool close_fd_when_done)
 {
     char *to_set = input;
 
     if (dup) {
-	free   = true;
-	to_set = (char *)calloc(len + 1, 1);
-	memcpy(to_set, input, len);
+        free   = true;
+        to_set = (char *)calloc(len + 1, 1);
+        memcpy(to_set, input, len);
     }
     party->open_for_read        = true;
     party->open_for_write       = false;
@@ -293,35 +293,35 @@ sb_init_party_input_buf(switchboard_t *ctx, party_t *party, char *input,
 
 party_t *
 sb_new_party_input_buf(switchboard_t *ctx, char *input, size_t len,
-		       bool dup, bool free, bool close_fd_when_done)
+                       bool dup, bool free, bool close_fd_when_done)
 {
     party_t *result = (party_t *)calloc(sizeof(party_t), 1);
     sb_init_party_input_buf(ctx, result, input, len, dup, free,
-			    close_fd_when_done);
+                            close_fd_when_done);
 
     return result;
 }
 
 void
 sb_party_input_buf_new_string(party_t *party, char *input, size_t len,
-			      bool dup, bool close_fd_when_done)
+                              bool dup, bool close_fd_when_done)
 {
     if (party->party_type != PT_STRING || !party->can_read_from_it) {
-	return;
+        return;
     }
     str_src_party_t *sobj = get_sstr_obj(party);
     if (sobj->free_on_close && sobj->strbuf) {
-	free(sobj->strbuf);
+        free(sobj->strbuf);
     }
     sobj->len                = len;
     sobj->close_fd_when_done = close_fd_when_done;
 
     if (dup) {
-	sobj->strbuf = (char *)calloc(len + 1, 1);
-	memcpy(sobj->strbuf, input, len);
-	sobj->free_on_close = true;
+        sobj->strbuf = (char *)calloc(len + 1, 1);
+        memcpy(sobj->strbuf, input, len);
+        sobj->free_on_close = true;
     } else {
-	sobj->strbuf = input;
+        sobj->strbuf = input;
     }
 }
 
@@ -338,16 +338,16 @@ sb_party_input_buf_new_string(party_t *party, char *input, size_t len,
  */
 void
 sb_init_party_output_buf(switchboard_t *ctx, party_t *party, char *tag,
-		      size_t buflen)
+                         size_t buflen)
 {
     if (buflen < PIPE_BUF) {
-	buflen = PIPE_BUF;
+        buflen = PIPE_BUF;
     }
 
     size_t n = buflen / PIPE_BUF;
 
     if (buflen % PIPE_BUF) {
-	n++;
+        n++;
     }
 
     party->can_read_from_it     = false;
@@ -404,8 +404,8 @@ sb_init_party_callback(switchboard_t *ctx, party_t *party, switchboard_cb_t cb)
  */
 void
 sb_monitor_pid(switchboard_t *ctx, pid_t pid, party_t *stdin_fd_party,
-	       party_t *stdout_fd_party, party_t *stderr_fd_party,
-	       bool shutdown)
+               party_t *stdout_fd_party, party_t *stderr_fd_party,
+               bool shutdown)
 {
     monitor_t *monitor = (monitor_t *)calloc(sizeof(monitor_t), 1);
 
@@ -473,7 +473,7 @@ get_msg_slot(switchboard_t *ctx)
     sb_heap_t *heap;
 
     if (!ctx->heap || (ctx->heap->cur_cell >= ctx->heap_elems)) {
-	add_heap(ctx);
+        add_heap(ctx);
     }
 
     if (ctx->freelist != NULL) {
@@ -481,9 +481,9 @@ get_msg_slot(switchboard_t *ctx)
         ctx->freelist = result->next;
 
         #ifdef SB_DEBUG
-	printf("get_slot: freelist (%p). New freelist: %p\n",
-	       result, ctx->freelist);
-	#endif
+        printf("get_slot: freelist (%p). New freelist: %p\n",
+               result, ctx->freelist);
+        #endif
         return result;
     }
 
@@ -518,25 +518,25 @@ static inline void
 publish(switchboard_t *ctx, char *buf, ssize_t len, party_t *party)
 {
     if (!party->open_for_write) {
-	return;
+        return;
     }
 
     fd_party_t *receiver = get_fd_obj(party);
     sb_msg_t   *msg      = get_msg_slot(ctx);
 
     if (len) {
-	memcpy(msg->data, buf, len);
-	msg->len       = len;
+        memcpy(msg->data, buf, len);
+        msg->len       = len;
     } else {
-	msg->len = 0;
+        msg->len = 0;
     }
 
     msg->next = NULL;
 
     if (receiver->first_msg == NULL) {
-	receiver->first_msg = msg;
+        receiver->first_msg = msg;
     } else {
-	receiver->last_msg->next = msg;
+        receiver->last_msg->next = msg;
     }
 
     receiver->last_msg = msg;
@@ -570,7 +570,7 @@ bool
 sb_route(switchboard_t *ctx, party_t *read_from, party_t *write_to)
 {
     if (read_from == NULL || write_to == NULL) {
-	return false;
+        return false;
     }
 
     if (!read_from->open_for_read || !write_to->open_for_write) {
@@ -578,70 +578,70 @@ sb_route(switchboard_t *ctx, party_t *read_from, party_t *write_to)
     }
 
     if (read_from->party_type & (PT_LISTENER | PT_CALLBACK)) {
-	return false;
+        return false;
     }
 
     if (write_to->party_type & PT_LISTENER) {
-	return false;
+        return false;
     }
 
     if (read_from->party_type == PT_STRING) {
-	if (write_to->party_type != PT_FD) {
-	    return false;
-	}
-	str_src_party_t *s         = get_sstr_obj(read_from);
-	size_t           remaining = s->len;
-	char            *p         = s->strbuf;
-	char            *end       = p + remaining;
-	int              total     = 0;
+        if (write_to->party_type != PT_FD) {
+            return false;
+        }
+        str_src_party_t *s         = get_sstr_obj(read_from);
+        size_t           remaining = s->len;
+        char            *p         = s->strbuf;
+        char            *end       = p + remaining;
+        int              total     = 0;
 
-	while (p < (end - SB_MSG_LEN)) {
-	    publish(ctx, p, SB_MSG_LEN, write_to);
-	    p     += SB_MSG_LEN;
-	    total += SB_MSG_LEN;
-	}
-	if (p != end) {
-	    publish(ctx, p, end - p, write_to);
-	    total += end - p;
-	}
+        while (p < (end - SB_MSG_LEN)) {
+            publish(ctx, p, SB_MSG_LEN, write_to);
+            p     += SB_MSG_LEN;
+            total += SB_MSG_LEN;
+        }
+        if (p != end) {
+            publish(ctx, p, end - p, write_to);
+            total += end - p;
+        }
 
-	if (s->close_fd_when_done) {
-	    publish(ctx, NULL, 0, write_to);
-	}
+        if (s->close_fd_when_done) {
+            publish(ctx, NULL, 0, write_to);
+        }
 
-	return true;
+        return true;
     }
     else {
-	// Will be PT_FD.
-	fd_party_t     *r_fd_obj = get_fd_obj(read_from);
+        // Will be PT_FD.
+        fd_party_t     *r_fd_obj = get_fd_obj(read_from);
 
-	subscription_t *subscription;
-	subscription = (subscription_t *)calloc(sizeof(subscription_t), 1);
+        subscription_t *subscription;
+        subscription = (subscription_t *)calloc(sizeof(subscription_t), 1);
 
-	if (write_to->party_type == PT_FD) {
+        if (write_to->party_type == PT_FD) {
             #if defined(SB_DEBUG) || defined(SB_TEST)
-	    printf("sub(src_fd=%d, dst_fd=%d)\n",
-		   party_fd(read_from), party_fd(write_to));
-	    #endif
-	}
-	else if (write_to->party_type == PT_CALLBACK) {
-            #if defined(SB_DEBUG) || defined(SB_TEST)
-	    printf("sub(src_fd=%d, dst = callback)\n",
-		   party_fd(read_from));
-	    #endif
-	}
-        else {
-	    str_dst_party_t *dob = get_dstr_obj(write_to);
-	    if (!dob->tag) {
-		return false;
-	    }
-	    #if defined(SB_DEBUG) || defined(SB_TEST)
-	    printf("sub(src=%d, tag=%s)\n", party_fd(read_from), dob->tag);
-	    #endif
+            printf("sub(src_fd=%d, dst_fd=%d)\n",
+                   party_fd(read_from), party_fd(write_to));
+            #endif
         }
-	subscription->subscriber = write_to;
-	subscription->next       = r_fd_obj->subscribers;
-	r_fd_obj->subscribers    = subscription;
+        else if (write_to->party_type == PT_CALLBACK) {
+            #if defined(SB_DEBUG) || defined(SB_TEST)
+            printf("sub(src_fd=%d, dst = callback)\n",
+                   party_fd(read_from));
+            #endif
+        }
+        else {
+            str_dst_party_t *dob = get_dstr_obj(write_to);
+            if (!dob->tag) {
+                return false;
+            }
+            #if defined(SB_DEBUG) || defined(SB_TEST)
+            printf("sub(src=%d, tag=%s)\n", party_fd(read_from), dob->tag);
+            #endif
+        }
+        subscription->subscriber = write_to;
+        subscription->next       = r_fd_obj->subscribers;
+        r_fd_obj->subscribers    = subscription;
     }
 
     return true;
@@ -660,23 +660,23 @@ bool
 sb_pause_route(switchboard_t *ctx, party_t *read_from, party_t *write_to)
 {
     if (read_from == NULL || write_to == NULL) {
-	return false;
+        return false;
     }
 
     fd_party_t     *reader = get_fd_obj(read_from);
     subscription_t *cur    = reader->subscribers;
 
     while (cur != NULL) {
-	if (cur->subscriber != write_to) {
-	    cur  = cur->next;
-	    continue;
-	}
-	if (cur->paused) {
-	    return false;
-	} else {
-	    cur->paused = true;
-	    return true;
-	}
+        if (cur->subscriber != write_to) {
+            cur  = cur->next;
+            continue;
+        }
+        if (cur->paused) {
+            return false;
+        } else {
+            cur->paused = true;
+            return true;
+        }
     }
     return false;
 }
@@ -690,23 +690,23 @@ bool
 sb_resume_route(switchboard_t *ctx, party_t *read_from, party_t *write_to)
 {
     if (read_from == NULL || write_to == NULL) {
-	return false;
+        return false;
     }
 
     fd_party_t     *reader = get_fd_obj(read_from);
     subscription_t *cur    = reader->subscribers;
 
     while (cur != NULL) {
-	if (cur->subscriber != write_to) {
-	    cur  = cur->next;
-	    continue;
-	}
-	if (cur->paused) {
-	    cur->paused = true;
-	    return true;
-	} else {
-	    return false;
-	}
+        if (cur->subscriber != write_to) {
+            cur  = cur->next;
+            continue;
+        }
+        if (cur->paused) {
+            cur->paused = true;
+            return true;
+        } else {
+            return false;
+        }
     }
     return false;
 }
@@ -718,7 +718,7 @@ bool
 sb_route_is_active(switchboard_t *ctx, party_t *read_from, party_t *write_to)
 {
     if (read_from == NULL || write_to == NULL) {
-	return false;
+        return false;
     }
 
     if (!read_from->open_for_read || !write_to->open_for_write) {
@@ -729,11 +729,11 @@ sb_route_is_active(switchboard_t *ctx, party_t *read_from, party_t *write_to)
     subscription_t *cur    = reader->subscribers;
 
     while (cur != NULL) {
-	if (cur->subscriber != write_to) {
-	    cur  = cur->next;
-	    continue;
-	}
-	return !cur->paused;
+        if (cur->subscriber != write_to) {
+            cur  = cur->next;
+            continue;
+        }
+        return !cur->paused;
     }
     return false;
 }
@@ -745,7 +745,7 @@ bool
 sb_route_is_paused(switchboard_t *ctx, party_t *read_from, party_t *write_to)
 {
     if (read_from == NULL || write_to == NULL) {
-	return false;
+        return false;
     }
 
     if (!read_from->open_for_read || !write_to->open_for_write) {
@@ -756,11 +756,11 @@ sb_route_is_paused(switchboard_t *ctx, party_t *read_from, party_t *write_to)
     subscription_t *cur    = reader->subscribers;
 
     while (cur != NULL) {
-	if (cur->subscriber != write_to) {
-	    cur  = cur->next;
-	    continue;
-	}
-	return cur->paused;
+        if (cur->subscriber != write_to) {
+            cur  = cur->next;
+            continue;
+        }
+        return cur->paused;
     }
     return false;
 }
@@ -773,7 +773,7 @@ bool
 sb_is_subscribed(switchboard_t *ctx, party_t *read_from, party_t *write_to)
 {
     if (read_from == NULL || write_to == NULL) {
-	return false;
+        return false;
     }
 
     if (!read_from->open_for_read || !write_to->open_for_write) {
@@ -784,11 +784,11 @@ sb_is_subscribed(switchboard_t *ctx, party_t *read_from, party_t *write_to)
     subscription_t *cur    = reader->subscribers;
 
     while (cur != NULL) {
-	if (cur->subscriber != write_to) {
-	    cur  = cur->next;
-	    continue;
-	}
-	return true;
+        if (cur->subscriber != write_to) {
+            cur  = cur->next;
+            continue;
+        }
+        return true;
     }
     return false;
 }
@@ -836,45 +836,45 @@ set_fdinfo(switchboard_t *ctx)
     cur = ctx->parties_for_reading;
 
     while (cur != NULL) {
-	fd_party_t     *r_fd_obj    = get_fd_obj(cur);
-	subscription_t *subscribers = r_fd_obj->subscribers;
+        fd_party_t     *r_fd_obj    = get_fd_obj(cur);
+        subscription_t *subscribers = r_fd_obj->subscribers;
 
-	if (cur->open_for_read) {
-	    while (subscribers != NULL) {
-		if (cur->party_type == PT_FD) {
-		    party_t *onesub = subscribers->subscriber;
+        if (cur->open_for_read) {
+            while (subscribers != NULL) {
+                if (cur->party_type == PT_FD) {
+                    party_t *onesub = subscribers->subscriber;
 
-		    if (onesub && onesub->open_for_write) {
-			FD_SET(party_fd(cur), &ctx->readset);
-			open = true;
-			break;
+                    if (onesub && onesub->open_for_write) {
+                        FD_SET(party_fd(cur), &ctx->readset);
+                        open = true;
+                        break;
 
-		    }
-		} else {
-		    open = true;
-		    FD_SET(party_fd(cur), &ctx->readset);
-		    break;
-		}
-	       subscribers = subscribers->next;
-	    }
-	}
-	cur = cur->next_reader;
+                    }
+                } else {
+                    open = true;
+                    FD_SET(party_fd(cur), &ctx->readset);
+                    break;
+                }
+                subscribers = subscribers->next;
+            }
+        }
+        cur = cur->next_reader;
     }
 
     cur = ctx->parties_for_writing;
     while (cur != NULL) {
-	if (cur->party_type == PT_FD && cur->open_for_write &&
-	    cur->info.fdinfo.first_msg != NULL) {
-	    open = true;
-	    FD_SET(party_fd(cur), &ctx->writeset);
-	}
-	cur = cur->next_writer;
+        if (cur->party_type == PT_FD && cur->open_for_write &&
+            cur->info.fdinfo.first_msg != NULL) {
+            open = true;
+            FD_SET(party_fd(cur), &ctx->writeset);
+        }
+        cur = cur->next_writer;
     }
 
     // If nothing w/ a file descriptor is left standing, then we will
     // finish up.
     if (!open) {
-	ctx->done = true;
+        ctx->done = true;
     }
 }
 
@@ -890,11 +890,11 @@ void
 sb_set_io_timeout(switchboard_t *ctx, struct timeval *timeout)
 {
     if (timeout == NULL) {
-	ctx->io_timeout_ptr = NULL;
+        ctx->io_timeout_ptr = NULL;
     }
     else {
-	ctx->io_timeout_ptr = &ctx->io_timeout;
-	memcpy(ctx->io_timeout_ptr, timeout, sizeof(struct timeval));
+        ctx->io_timeout_ptr = &ctx->io_timeout;
+        memcpy(ctx->io_timeout_ptr, timeout, sizeof(struct timeval));
     }
 }
 
@@ -909,8 +909,8 @@ static inline bool
 reader_ready(switchboard_t *ctx, party_t *party)
 {
     if (party->open_for_read && FD_ISSET(party_fd(party), &ctx->readset) != 0) {
-	FD_CLR(party_fd(party), &ctx->writeset);
-	return true;
+        FD_CLR(party_fd(party), &ctx->writeset);
+        return true;
     }
     return false;
 }
@@ -920,8 +920,8 @@ static inline bool
 writer_ready(switchboard_t *ctx, party_t *party)
 {
     if (party->open_for_write &&
-	FD_ISSET(party_fd(party), &ctx->writeset) != 0) {
-	return true;
+        FD_ISSET(party_fd(party), &ctx->writeset) != 0) {
+        return true;
     }
     return false;
 }
@@ -941,21 +941,21 @@ add_data_to_string_out(str_dst_party_t *party, char *buf, ssize_t len) {
     #endif
 
     if (party->ix + len >= party->len) {
-	int newlen = party->len + len + party->step;
-	int rem    = newlen % party->step;
+        int newlen = party->len + len + party->step;
+        int rem    = newlen % party->step;
 
-	newlen       -= rem;
-	party->strbuf = realloc(party->strbuf, newlen);
+        newlen       -= rem;
+        party->strbuf = realloc(party->strbuf, newlen);
 
-	if (party->strbuf == 0) {
-	    #ifdef SB_DEBUG
-	    printf("REALLOC FAILED.  Skipping capture.\n");
-	    #endif
-	    return;
-	}
+        if (party->strbuf == 0) {
+            #ifdef SB_DEBUG
+            printf("REALLOC FAILED.  Skipping capture.\n");
+            #endif
+            return;
+        }
 
-	party->len = newlen;
-	memset(party->strbuf + party->ix, 0, newlen - party->ix);
+        party->len = newlen;
+        memset(party->strbuf + party->ix, 0, newlen - party->ix);
     }
 
     memcpy(&party->strbuf[party->ix], buf, len);
@@ -996,45 +996,63 @@ handle_one_read(switchboard_t *ctx, party_t *party)
     ssize_t read_result = read_one(party_fd(party), buf, SB_MSG_LEN);
 
     if (read_result <= 0) {
-	party->found_errno = errno;
-	party->open_for_read  = false;
-	#ifdef SB_DEBUG
-	printf("Shut down reading on fd %d in h1r top\n", party_fd(party));
-	#endif
-	if (party->stop_on_close) {
-	    ctx->done = true;
-	}
-    }
-    else {
-	#ifdef SB_DEBUG
-	printf(">>One read from fd %d", party_fd(party));
-	print_hex(buf, read_result, ": ");
-	#endif
+        if (read_result < 0) {
+            party->found_errno = errno;
+        }
+        party->open_for_read  = false;
+        #ifdef SB_DEBUG
+        printf("Shut down reading on fd %d in h1r top\n", party_fd(party));
+        #endif
+        if (party->stop_on_close) {
+            ctx->done = true;
+        }
 
-	fd_party_t     *obj     = get_fd_obj(party);
-	subscription_t *sublist = obj->subscribers;
+        /* When there is no input read, we need to propagate close
+         * to all the subscribers.
+         * As this happens via event-loop we can do that by passing
+         * empty write message to the subscriber
+         * (see comment in handle_one_write)
+         */
+        fd_party_t     *obj     = get_fd_obj(party);
+        subscription_t *sublist = obj->subscribers;
 
-	while (sublist != NULL) {
-	    party_t *sub = sublist->subscriber;
+        while (sublist != NULL) {
+            party_t *sub = sublist->subscriber;
+            if (sub->party_type == PT_FD) {
+                publish(ctx, "", 0, sub);
+            }
+            sublist = sublist->next;
+        }
+    } else {
+        #ifdef SB_DEBUG
+        printf(">>One read from fd %d", party_fd(party));
+        print_hex(buf, read_result, ": ");
+        #endif
 
-	    if (!sublist->paused) {
-		switch(sub->party_type) {
-		case PT_FD:
-		    publish(ctx, buf, read_result, sub);
-		    break;
-		case PT_STRING:
-		    add_data_to_string_out(get_dstr_obj(sub), buf, read_result);
-		    break;
-		case PT_CALLBACK:
-		    (*sub->info.cbinfo.callback)(ctx->extra, sub->extra, buf,
-						 (size_t)read_result);
-		    break;
-		default:
-		    break;
-		}
-	    }
-	    sublist = sublist->next;
-	}
+        fd_party_t     *obj     = get_fd_obj(party);
+        subscription_t *sublist = obj->subscribers;
+
+        while (sublist != NULL) {
+            party_t *sub = sublist->subscriber;
+
+            if (!sublist->paused) {
+                switch(sub->party_type) {
+                    case PT_FD:
+                        publish(ctx, buf, read_result, sub);
+                        break;
+                    case PT_STRING:
+                        add_data_to_string_out(get_dstr_obj(sub), buf, read_result);
+                        break;
+                    case PT_CALLBACK:
+                        (*sub->info.cbinfo.callback)(ctx->extra, sub->extra, buf,
+                                                     (size_t)read_result);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            sublist = sublist->next;
+        }
     }
 }
 
@@ -1051,21 +1069,21 @@ handle_one_accept(switchboard_t *ctx, party_t *party)
     socklen_t         address_len;
 
     while (true) {
-	int sockfd = accept(listener_fd, &address, &address_len);
+        int sockfd = accept(listener_fd, &address, &address_len);
 
-	if (sockfd >= 0) {
-	    (*listener_obj->accept_cb)(ctx, sockfd, &address, &address_len);
-	    break;
-	}
-	if (errno == EINTR || errno == EAGAIN) {
-	    continue;
-	}
-	if (errno == ECONNABORTED) {
-	    break;
-	}
-	party->found_errno   = errno;
-	party->open_for_read = false;
-	break;
+        if (sockfd >= 0) {
+            (*listener_obj->accept_cb)(ctx, sockfd, &address, &address_len);
+            break;
+        }
+        if (errno == EINTR || errno == EAGAIN) {
+            continue;
+        }
+        if (errno == ECONNABORTED) {
+            break;
+        }
+        party->found_errno   = errno;
+        party->open_for_read = false;
+        break;
     }
 }
 
@@ -1084,35 +1102,34 @@ handle_one_write(switchboard_t *ctx, party_t *party)
     fd_party_t *fdobj = get_fd_obj(party);
     sb_msg_t   *msg   = fdobj->first_msg;
 
-
     if (!msg) {
-	return;
+        return;
     }
 
     if (msg && (msg->next == NULL || msg == fdobj->last_msg)) {
-	fdobj->first_msg = NULL;
-	fdobj->last_msg = NULL;
+        fdobj->first_msg = NULL;
+        fdobj->last_msg = NULL;
     } else {
-	fdobj->first_msg = msg->next;
+        fdobj->first_msg = msg->next;
     }
 
     if (!msg->len) {
-	/* Real messages should always have lengths. We get passed a
-	 * zero-length message only if a string was fed in for input,
-	 * with instructions for us to close after it's consumed.
-	 *
-	 * The close instruction is communicated by sending a null
-	 * message. So when we see it, we mark ourselves as closed.
-	 */
+        /* Real messages should always have lengths. We get passed a
+         * zero-length message only if a string was fed in for input,
+         * with instructions for us to close after it's consumed.
+         *
+         * The close instruction is communicated by sending a null
+         * message. So when we see it, we mark ourselves as closed.
+         */
         #ifdef SB_DEBUG
-	printf("0-length write; shutting down write-side of fd.\n");
-	#endif
-	party->open_for_write = false;
-	if (!party->open_for_read) {
-	    close(party_fd(party));
-	}
-	free_msg_slot(ctx, msg);
-	return;
+        printf("0-length write; shutting down write-side of fd.\n");
+        #endif
+        party->open_for_write = false;
+        if (!party->open_for_read) {
+            close(party_fd(party));
+        }
+        free_msg_slot(ctx, msg);
+        return;
     }
 
     #ifdef SB_DEBUG
@@ -1121,32 +1138,32 @@ handle_one_write(switchboard_t *ctx, party_t *party)
     #endif
 
     if (!write_data(party_fd(party), msg->data, msg->len)) {
-	party->found_errno = errno;
+        party->found_errno = errno;
 
-	party->open_for_write = false;
-	if (!party->open_for_read) {
-	    close(party_fd(party));
-	}
+        party->open_for_write = false;
+        if (!party->open_for_read) {
+            close(party_fd(party));
+        }
 
-	if (party->stop_on_close) {
-	    ctx->done = true;
-	}
-	/* If the write failed, we'll never try to write again.
-	 * The message slot we tried to write gets freed below
-	 * no matter what, but let's free any other queued slots
-	 * here.
-	 */
-	sb_msg_t *to_free = fdobj->first_msg;
+        if (party->stop_on_close) {
+            ctx->done = true;
+        }
+        /* If the write failed, we'll never try to write again.
+     * The message slot we tried to write gets freed below
+     * no matter what, but let's free any other queued slots
+     * here.
+        */
+        sb_msg_t *to_free = fdobj->first_msg;
 
-	while (to_free) {
-	    sb_msg_t *next = to_free->next;
+        while (to_free) {
+            sb_msg_t *next = to_free->next;
 
-	    free_msg_slot(ctx, to_free);
-	    to_free = next;
-	}
-	fdobj->first_msg = NULL;
-	fdobj->last_msg  = NULL;
-	return;
+            free_msg_slot(ctx, to_free);
+            to_free = next;
+        }
+        fdobj->first_msg = NULL;
+        fdobj->last_msg  = NULL;
+        return;
     }
 
     free_msg_slot(ctx, msg);
@@ -1159,16 +1176,16 @@ handle_ready_reads(switchboard_t *ctx)
     party_t *reader = ctx->parties_for_reading;
 
     while(reader != NULL) {
-	if (reader_ready(ctx, reader)) {
-	    FD_CLR(party_fd(reader), &ctx->readset);
+        if (reader_ready(ctx, reader)) {
+            FD_CLR(party_fd(reader), &ctx->readset);
 
-	    if (reader->party_type == PT_FD) {
-		handle_one_read(ctx, reader);
-	    } else {
-		handle_one_accept(ctx, reader);
-	    }
-	}
-	reader = reader->next_reader;
+            if (reader->party_type == PT_FD) {
+                handle_one_read(ctx, reader);
+            } else {
+                handle_one_accept(ctx, reader);
+            }
+        }
+        reader = reader->next_reader;
     }
 }
 
@@ -1179,12 +1196,12 @@ handle_ready_writes(switchboard_t *ctx)
     party_t *writer = ctx->parties_for_writing;
 
     while (writer != NULL) {
-	if (writer_ready(ctx, writer)) {
-	    FD_CLR(party_fd(writer), &ctx->readset);
+        if (writer_ready(ctx, writer)) {
+            FD_CLR(party_fd(writer), &ctx->readset);
 
-	    handle_one_write(ctx, writer);
-	}
-	writer = writer->next_writer;
+            handle_one_write(ctx, writer);
+        }
+        writer = writer->next_writer;
     }
 }
 
@@ -1195,7 +1212,7 @@ subproc_mark_closed(monitor_t *proc, bool error)
     proc->closed = true;
 
     if (error) {
-	proc->found_errno = errno;
+        proc->found_errno = errno;
     }
 
     // We can mark the write side of this as closed right away. But we
@@ -1203,7 +1220,7 @@ subproc_mark_closed(monitor_t *proc, bool error)
     // first.
 
     if (proc->stdin_fd_party) {
-	proc->stdin_fd_party->open_for_write = false;
+        proc->stdin_fd_party->open_for_write = false;
     }
 }
 
@@ -1214,58 +1231,58 @@ sb_default_check_exit_conditions(switchboard_t *ctx)
     bool       close_if_drained = false;
 
     while (subproc) {
-	if (subproc->closed && subproc->shutdown_when_closed) {
-	    close_if_drained = true;
-	    break;
-	}
-	subproc = subproc->next;
+        if (subproc->closed && subproc->shutdown_when_closed) {
+            close_if_drained = true;
+            break;
+        }
+        subproc = subproc->next;
     }
 
     if (!close_if_drained) {
-	return false;
+        return false;
     }
 
     if (subproc->stdout_fd_party && subproc->stdout_fd_party->open_for_read) {
-	return false;
+        return false;
     } else {
         #if defined(SB_DEBUG) || defined(SB_TEST)
-	printf("Subproc stdout is closed for business.\n");
-	#endif
+        printf("Subproc stdout is closed for business.\n");
+        #endif
     }
 
     if (subproc->stderr_fd_party && subproc->stderr_fd_party->open_for_read) {
         #if defined(SB_DEBUG) || defined(SB_TEST)
-	printf("Read side of stderr is still open.\n");
-	#endif
-	return false;
+        printf("Read side of stderr is still open.\n");
+        #endif
+        return false;
     }
 
     party_t *writers = ctx->parties_for_writing;
 
     while (writers) {
 
-	if (writers->party_type == PT_FD) {
-	    fd_party_t *fd_writer = get_fd_obj(writers);
+        if (writers->party_type == PT_FD) {
+            fd_party_t *fd_writer = get_fd_obj(writers);
 
             #if defined(SB_DEBUG) || defined(SB_TEST)
-	    printf("checking for pending writes to fd %d\n", fd_writer->fd);
-	    #endif
-	    if (writers->open_for_write && fd_writer->first_msg) {
+            printf("checking for pending writes to fd %d\n", fd_writer->fd);
+            #endif
+            if (writers->open_for_write && fd_writer->first_msg) {
                 #if defined(SB_DEBUG) || defined(SB_TEST)
-		printf("Don't exit yet.\n");
-		#endif
-		return false;
-	    }
+                printf("Don't exit yet.\n");
+                #endif
+                return false;
+            }
             #if defined(SB_DEBUG) || defined(SB_TEST)
-	    if (writers->open_for_write) {
-		printf("No queue.\n");
-	    }
-	    else {
-		printf("Already closed.\n");
-	    }
-	    #endif
+            if (writers->open_for_write) {
+                printf("No queue.\n");
+            }
+            else {
+                printf("Already closed.\n");
+            }
+            #endif
         }
-	writers = writers->next_writer;
+        writers = writers->next_writer;
     }
 
     return true;
@@ -1279,35 +1296,35 @@ process_status_check(monitor_t *subproc, bool wait_on_exit)
 
 
     if (wait_on_exit) {
-	flag = 0;
+        flag = 0;
     } else {
-	flag = WNOHANG;
+        flag = WNOHANG;
     }
 
     if (subproc->closed) {
-	return;
+        return;
     }
 
     while (true) {
-	switch (waitpid(subproc->pid, &stat_info, flag)) {
-	case 0:
-	    return; // Process is sill running.
-	case -1:
-	    if (errno == EINTR) {
-		continue;
-	    }
-	    subproc->closed      = true;
-	    subproc->found_errno = errno;
-	    return;
-	default:
-	    subproc->closed      = true;
-	    subproc->exit_status = WEXITSTATUS(stat_info);
+        switch (waitpid(subproc->pid, &stat_info, flag)) {
+            case 0:
+                return; // Process is sill running.
+            case -1:
+                if (errno == EINTR) {
+                    continue;
+                }
+                subproc->closed      = true;
+                subproc->found_errno = errno;
+                return;
+            default:
+                subproc->closed      = true;
+                subproc->exit_status = WEXITSTATUS(stat_info);
 
-	    if (WIFSIGNALED(stat_info)) {
-		subproc->term_signal = WTERMSIG(stat_info);
-	    }
-	    return;
-	}
+                if (WIFSIGNALED(stat_info)) {
+                    subproc->term_signal = WTERMSIG(stat_info);
+                }
+                return;
+        }
     }
 }
 
@@ -1331,19 +1348,19 @@ handle_loop_end(switchboard_t *ctx)
     monitor_t *subproc = ctx->pid_watch_list;
 
     while (subproc != NULL) {
-	process_status_check(subproc, false);
-	subproc = subproc->next;
+        process_status_check(subproc, false);
+        subproc = subproc->next;
     }
 
     if (!ctx->progress_callback) {
-	ctx->progress_callback =
-	    (progress_cb_decl)sb_default_check_exit_conditions;
+        ctx->progress_callback =
+            (progress_cb_decl)sb_default_check_exit_conditions;
     }
 
     if (!ctx->progress_on_timeout_only) {
-	if ((*ctx->progress_callback)(ctx)) {
-	    ctx->done = true;
-	}
+        if ((*ctx->progress_callback)(ctx)) {
+            ctx->done = true;
+        }
     }
 }
 
@@ -1358,10 +1375,10 @@ is_registered_writer(switchboard_t *ctx, party_t *target)
     party_t *cur = ctx->parties_for_writing;
 
     while (cur) {
-	if (target == cur) {
-	    return true;
-	}
-	cur = cur->next_writer;
+        if (target == cur) {
+            return true;
+        }
+        cur = cur->next_writer;
     }
 
     return false;
@@ -1377,15 +1394,15 @@ void
 sb_destroy(switchboard_t *ctx, bool free_parties)
 {
     while (ctx->heap) {
-	sb_heap_t *to_free = ctx->heap;
-	ctx->heap          = ctx->heap->next;
-	free(to_free);
+        sb_heap_t *to_free = ctx->heap;
+        ctx->heap          = ctx->heap->next;
+        free(to_free);
     }
 
     while (ctx->pid_watch_list) {
-	monitor_t *to_free  = ctx->pid_watch_list;
-	ctx->pid_watch_list = ctx->pid_watch_list->next;
-	free(to_free);
+        monitor_t *to_free  = ctx->pid_watch_list;
+        ctx->pid_watch_list = ctx->pid_watch_list->next;
+        free(to_free);
     }
 
     party_t *cur, *next;
@@ -1393,57 +1410,57 @@ sb_destroy(switchboard_t *ctx, bool free_parties)
     cur = ctx->parties_for_reading;
 
     while (cur) {
-	if (cur->close_on_destroy) {
-	    if (cur->party_type & (PT_FD | PT_LISTENER) ) {
-		close(party_fd(cur));
-	    }
-	}
+        if (cur->close_on_destroy) {
+            if (cur->party_type & (PT_FD | PT_LISTENER) ) {
+                close(party_fd(cur));
+            }
+        }
 
-	fd_party_t     *fdobj = get_fd_obj(cur);
-	subscription_t *sub   = fdobj->subscribers;
+        fd_party_t     *fdobj = get_fd_obj(cur);
+        subscription_t *sub   = fdobj->subscribers;
 
-	while (sub) {
-	    subscription_t *next_sub = sub->next;
-	    free(sub);
-	    sub = next_sub;
-	}
+        while (sub) {
+            subscription_t *next_sub = sub->next;
+            free(sub);
+            sub = next_sub;
+        }
 
-	if (cur->party_type == PT_STRING) {
-	    str_src_party_t *sstr = get_sstr_obj(cur);
-	    if (sstr->strbuf != NULL) {
-		free(sstr->strbuf);
-	    }
-	}
-	next = cur->next_reader;
+        if (cur->party_type == PT_STRING) {
+            str_src_party_t *sstr = get_sstr_obj(cur);
+            if (sstr->strbuf != NULL) {
+                free(sstr->strbuf);
+            }
+        }
+        next = cur->next_reader;
 
-	if (free_parties) {
-	    if (!cur->can_write_to_it || !is_registered_writer(ctx, cur)) {
-		free(cur);
-	    }
-	}
-	cur = next;
+        if (free_parties) {
+            if (!cur->can_write_to_it || !is_registered_writer(ctx, cur)) {
+                free(cur);
+            }
+        }
+        cur = next;
     }
 
     cur = ctx->parties_for_writing;
     while (cur) {
-	if (cur->close_on_destroy && cur->party_type == PT_FD) {
-	    close(party_fd(cur));
-	}
-	next = cur->next_writer;
-	if (free_parties) {
-	    free(cur);
-	}
-	cur = next;
+        if (cur->close_on_destroy && cur->party_type == PT_FD) {
+            close(party_fd(cur));
+        }
+        next = cur->next_writer;
+        if (free_parties) {
+            free(cur);
+        }
+        cur = next;
     }
 
     if (free_parties) {
-	cur = ctx->party_loners;
+        cur = ctx->party_loners;
 
-	while (cur) {
-	    next = cur->next_loner;
-	    free(cur);
-	    cur = next;
-	}
+        while (cur) {
+            next = cur->next_loner;
+            free(cur);
+            cur = next;
+        }
     }
 }
 
@@ -1459,16 +1476,16 @@ sb_get_results(switchboard_t *ctx, sb_result_t *result)
     int               ix        = 0;
 
     if (result->inited) {
-	return;
+        return;
     }
 
     result->inited = true;
 
     while (party) {
-	if (party->party_type == PT_STRING && party->can_write_to_it) {
-	    capcount++;
-	}
-	party = party->next_loner;
+        if (party->party_type == PT_STRING && party->can_write_to_it) {
+            capcount++;
+        }
+        party = party->next_loner;
     }
 
     result->num_captures    = capcount;
@@ -1477,24 +1494,24 @@ sb_get_results(switchboard_t *ctx, sb_result_t *result)
     party = ctx->party_loners;
 
     while (party) {
-	if (party->party_type == PT_STRING && party->can_write_to_it) {
-	    capture_result_t *r = result->captures + ix;
+        if (party->party_type == PT_STRING && party->can_write_to_it) {
+            capture_result_t *r = result->captures + ix;
 
-	    strobj = get_dstr_obj(party);
-	    r->tag = strobj->tag;
-	    r->len = strobj->ix;
+            strobj = get_dstr_obj(party);
+            r->tag = strobj->tag;
+            r->len = strobj->ix;
 
-	    if (strobj->ix) {
-		r->contents = strobj->strbuf;
+            if (strobj->ix) {
+                r->contents = strobj->strbuf;
 
-		strobj->strbuf = 0;
-		strobj->ix     = 0;
-	    } else {
-		r->contents = NULL;
-	    }
-	    ix += 1;
-	}
-	party = party->next_loner;
+                strobj->strbuf = 0;
+                strobj->ix     = 0;
+            } else {
+                r->contents = NULL;
+            }
+            ix += 1;
+        }
+        party = party->next_loner;
     }
 }
 
@@ -1504,14 +1521,14 @@ sb_result_get_capture(sb_result_t *ctx, char *tag, bool caller_borrow)
     char *result;
 
     for (int i = 0; i < ctx->num_captures; i++) {
-	if (!strcmp(ctx->captures[i].tag, tag)) {
-	    result = ctx->captures[i].contents;
+        if (!strcmp(ctx->captures[i].tag, tag)) {
+            result = ctx->captures[i].contents;
 
-	    if (!caller_borrow) {
-		ctx->captures[i].contents = NULL;
-	    }
-	    return result;
-	}
+            if (!caller_borrow) {
+                ctx->captures[i].contents = NULL;
+            }
+            return result;
+        }
     }
     return NULL;
 }
@@ -1525,9 +1542,9 @@ sb_result_get_capture(sb_result_t *ctx, char *tag, bool caller_borrow)
 void
 sb_result_destroy(sb_result_t *ctx) {
     for (int i = 0; i < ctx->num_captures; i++) {
-	if(ctx->captures[i].contents) {
-	    free(ctx->captures[i].contents);
-	}
+        if(ctx->captures[i].contents) {
+            free(ctx->captures[i].contents);
+        }
     }
     free(ctx->captures);
 }
@@ -1541,14 +1558,14 @@ waiting_writes(switchboard_t *ctx)
     party_t *writer = ctx->parties_for_writing;
 
     while(writer) {
-	if (writer->open_for_write) {
-	    fd_party_t *fd_obj = get_fd_obj(writer);
+        if (writer->open_for_write) {
+            fd_party_t *fd_obj = get_fd_obj(writer);
 
-	    if (fd_obj->first_msg != NULL) {
-		return true;
-	    }
-	}
-	writer = writer->next_writer;
+            if (fd_obj->first_msg != NULL) {
+                return true;
+            }
+        }
+        writer = writer->next_writer;
     }
 
     return false;
@@ -1563,21 +1580,30 @@ bool
 sb_operate_switchboard(switchboard_t *ctx, bool loop)
 {
     if (ctx->done && !waiting_writes(ctx)) {
-	return true;
+        return true;
     }
     do {
-	set_fdinfo(ctx);
-	if (sb_default_check_exit_conditions(ctx)) {
-	    return true;
-	}
-	if (ctx->done && !waiting_writes(ctx)) {
-		return true;
-	}
-	ctx->fds_ready = select(ctx->max_fd, &ctx->readset, &ctx->writeset,
-				NULL, ctx->io_timeout_ptr);
-	handle_ready_reads(ctx);
-	handle_ready_writes(ctx);
-	handle_loop_end(ctx);
+        set_fdinfo(ctx);
+        if (sb_default_check_exit_conditions(ctx)) {
+            return true;
+        }
+        if (ctx->done && !waiting_writes(ctx)) {
+            return true;
+        }
+        ctx->fds_ready = select(ctx->max_fd, &ctx->readset, &ctx->writeset,
+                                NULL, ctx->io_timeout_ptr);
+        if (ctx->fds_ready > 0) {
+            handle_ready_reads(ctx);
+            handle_ready_writes(ctx);
+            handle_loop_end(ctx);
+        } else if (ctx->fds_ready == -1) {
+            // select returned error
+            if (errno == EINTR) {
+                continue;
+            }
+            ctx->done = true;
+            return false;
+        }
     } while(loop);
     return false;
 }

--- a/nimutils/c/switchboard.h
+++ b/nimutils/c/switchboard.h
@@ -89,6 +89,7 @@ typedef struct {
     sb_msg_t       *first_msg;
     sb_msg_t       *last_msg;
     subscription_t *subscribers;
+    bool            close_fd_when_done; // Close the fd after writing?
 } fd_party_t;
 
 /*
@@ -309,8 +310,8 @@ extern void sb_init_party_listener(switchboard_t *, party_t *, int,
 	 		        accept_cb_t, bool, bool);
 extern party_t * sb_new_party_listener(switchboard_t *, int, accept_cb_t, bool,
 				    bool);
-extern void sb_init_party_fd(switchboard_t *, party_t *, int , int , bool, bool);
-extern party_t *sb_new_party_fd(switchboard_t *, int, int, bool, bool);
+extern void sb_init_party_fd(switchboard_t *, party_t *, int , int , bool, bool, bool);
+extern party_t *sb_new_party_fd(switchboard_t *, int, int, bool, bool, bool);
 extern void sb_init_party_input_buf(switchboard_t *, party_t *, char *,
 				    size_t, bool, bool, bool);
 extern party_t *sb_new_party_input_buf(switchboard_t *, char *, size_t,
@@ -342,7 +343,7 @@ extern bool sb_operate_switchboard(switchboard_t *, bool);
 extern void sb_get_results(switchboard_t *, sb_result_t *);
 extern char *sb_result_get_capture(sb_result_t *, char *, bool);
 extern void sb_result_destroy(sb_result_t *);
-extern void subproc_init(subprocess_t *, char *, char *[]);
+extern void subproc_init(subprocess_t *, char *, char *[], bool);
 extern bool subproc_set_envp(subprocess_t *, char *[]);
 extern bool subproc_pass_to_stdin(subprocess_t *, char *, size_t, bool);
 extern bool subproc_set_passthrough(subprocess_t *, unsigned char, bool);

--- a/nimutils/c/switchboard.h
+++ b/nimutils/c/switchboard.h
@@ -89,7 +89,7 @@ typedef struct {
     sb_msg_t       *first_msg;
     sb_msg_t       *last_msg;
     subscription_t *subscribers;
-    bool            close_fd_when_done; // Close the fd after writing?
+    bool            proxy_close; // close fd when proxy input is closed
 } fd_party_t;
 
 /*
@@ -258,6 +258,7 @@ typedef struct {
     int             signal_fd;
     int             pty_fd;
     bool            pty_stdin_pipe;
+    bool            proxy_stdin_close;
     bool            use_pty;
     bool            str_waiting;
     char           *cmd;

--- a/nimutils/c/switchboard.h
+++ b/nimutils/c/switchboard.h
@@ -236,7 +236,7 @@ typedef struct switchboard_t {
     fd_set            readset;
     fd_set            writeset;
     int               max_fd;
-    int               fds_ready; // Used to determine if we timed out.
+    int               fds_ready;
     party_t          *parties_for_reading;
     party_t          *parties_for_writing;
     party_t          *party_loners;

--- a/nimutils/subproc.nim
+++ b/nimutils/subproc.nim
@@ -467,10 +467,13 @@ proc runCmdGetEverything*(exe:  string,
   ## process.  This is similar to Nim's `execCmdEx` but allows for
   ## optional passthrough, timeouts, and sending an input string to
   ## stdin.
-  return runCommand(exe, args, newStdin, closeStdin, pty = false,
+  let isStdInTTY = isatty(0) != 0
+  return runCommand(exe, args, newStdin, closeStdin,
+                    pty         = if passthrough: isStdInTTY else: false,
                     passthrough = if passthrough: SpIoAll else: SpIoNone,
-                    timeoutUSec = timeoutUsec, capture = SpIoOutErr,
-                                  waitForExit = ensureExit)
+                    timeoutUSec = timeoutUsec,
+                    capture     = SpIoOutErr,
+                    waitForExit = ensureExit)
 
 proc runPager*(s: string) =
   var

--- a/nimutils/subproc.nim
+++ b/nimutils/subproc.nim
@@ -63,7 +63,8 @@ proc tcsetattr*(fd: cint, opt: TcsaConst, info: var Termcap):
               cint {. cdecl, importc, header: "<termios.h>", discardable.}
 proc termcap_get*(termcap: var Termcap) {.sproc.}
 proc termcap_set*(termcap: var Termcap) {.sproc.}
-proc subproc_init(ctx: var SubProcess, cmd: cstring, args: cStringArray)
+proc subproc_init(ctx: var SubProcess, cmd: cstring, args: cStringArray,
+                  closeStdinWhenDone: bool)
     {.sproc.}
 proc subproc_set_envp(ctx: var SubProcess, args: cStringArray)
     {.sproc.}
@@ -271,12 +272,12 @@ template binaryCstringToString*(s: cstring, l: int): string =
 # for the time being. We should clean them up in a destructor.
 
 proc initSubProcess*(ctx: var SubProcess, cmd: string,
-                      args: openarray[string]) =
+                     args: openarray[string], closeStdinWhenDone: bool) =
   ## Initialize a subprocess with the command to call. This does *NOT*
   ## run the sub-process. Instead, you can first configure it, and
   ## then call `run()` when ready.
   var cargs = allocCstringArray(args)
-  subproc_init(ctx, cstring(cmd), cargs)
+  subproc_init(ctx, cstring(cmd), cargs, closeStdinWhenDone)
 
 proc setEnv*(ctx: var SubProcess, env: openarray[string]) =
   ## Explicitly set the environment the subprocess should inherit. If
@@ -352,7 +353,8 @@ type ExecOutput* = ref object
 proc runCommand*(exe:  string,
                  args: seq[string],
                  newStdin                = "",
-                 closeStdIn              = false,
+                 closeStdin              = false,
+                 closeStdinWhenDone      = true,
                  pty                     = false,
                  passthrough             = SpIoNone,
                  passStderrToStdout      = false,
@@ -369,10 +371,12 @@ proc runCommand*(exe:  string,
   ## - `exe`: The path to the executable to run.
   ## - `args`: The arguments to pass. DO NOT include `exe` again as
   ##           the first argument, as it is automatically added.
-  ## - `newStdIn`: If not empty, the contents will be fed to the subprocess
+  ## - `newStdin`: If not empty, the contents will be fed to the subprocess
   ##               after it starts.
-  ## - `closeStdIn`: If true, will close stdin after writing the contents
-  ##                 of `newStdIn` to the subprocess.
+  ## - `closeStdin`: If true, will close stdin after writing the contents
+  ##                 of `newStdin` to the subprocess.
+  ## - `closeStdinWhenDone`: If true, will close stdin after passthrough stdin
+  ##                         is closed.
   ## - `pty`: Whether to use a pseudo-terminal (pty) to run the sub-process.
   ## - `passthrough`: Whether to proxy between the parent's stdin/stdout/stderr
   ##                  and the child's. You can specify which ones to proxy.
@@ -406,7 +410,7 @@ proc runCommand*(exe:  string,
   timeout.tv_sec  = Time(timeoutUsec / 1000000)
   timeout.tv_usec = Suseconds(timeoutUsec mod 1000000)
 
-  subproc.initSubprocess(binloc, @[exe] & args)
+  subproc.initSubprocess(binloc, @[exe] & args, closeStdinWhenDone)
   subproc.setTimeout(timeout)
 
   if len(env) != 0:
@@ -418,7 +422,7 @@ proc runCommand*(exe:  string,
   if capture != SpIoNone:
     subproc.setCapture(capture, combineCapture)
 
-  if newStdIn != "":
+  if newStdin != "":
     discard subproc.pipeToStdin(newStdin, closeStdin)
   subproc.run()
 
@@ -458,8 +462,8 @@ template runInteractiveCmd*(path: string,
 
 proc runCmdGetEverything*(exe:  string,
                           args: seq[string],
-                          newStdIn    = "",
-                          closeStdIn  = true,
+                          newStdin    = "",
+                          closeStdin  = true,
                           passthrough = false,
                           timeoutUsec = 1000000,
                           ensureExit  = true): ExecOutput =
@@ -467,9 +471,9 @@ proc runCmdGetEverything*(exe:  string,
   ## process.  This is similar to Nim's `execCmdEx` but allows for
   ## optional passthrough, timeouts, and sending an input string to
   ## stdin.
-  let isStdInTTY = isatty(0) != 0
+  let isStdinTTY = isatty(0) != 0
   return runCommand(exe, args, newStdin, closeStdin,
-                    pty         = if passthrough: isStdInTTY else: false,
+                    pty         = if passthrough: isStdinTTY else: false,
                     passthrough = if passthrough: SpIoAll else: SpIoNone,
                     timeoutUSec = timeoutUsec,
                     capture     = SpIoOutErr,

--- a/nimutils/switchboard.nim
+++ b/nimutils/switchboard.nim
@@ -65,7 +65,7 @@ proc sb_init*(ctx: var SwitchBoard, heap_elems: csize_t) {.sb.}
 
 proc sb_init_party_fd(ctx: var Switchboard, party: var Party, fd: cint,
                       perms: SbFdPerms, stopWhenClosed: bool,
-                      closeOnDestroy: bool) {.sb.}
+                      closeOnDestroy: bool, closeWhenDone: bool) {.sb.}
 
 proc initPartyCallback*(ctx: var Switchboard, party: var Party,
                         callback: SBCallback) {.cdecl,
@@ -182,7 +182,7 @@ proc setString*(party: var Party, input: string, closeAfter: bool = false) =
                                       true, true, closeAfter)
 proc initPartyFd*(ctx: var SwitchBoard, party: var Party, fd: int,
                   perms: SbFdPerms, stopWhenClosed = false,
-                  closeOnDestroy = false) =
+                  closeOnDestroy = false, closeWhenDone = true) =
   ## Initializes a file descriptor that can be both a subscriber and
   ## subscribed to, depending on the fd's permissions (which are
   ## passed, not discovered).
@@ -196,7 +196,7 @@ proc initPartyFd*(ctx: var SwitchBoard, party: var Party, fd: int,
   ## If `closeOnDestroy` is true, we will call close() on the fd for
   ## you whenever the switchboard is torn down.
   sb_init_party_fd(ctx, party, cint(fd), perms, stopWhenClosed,
-                   closeOnDestroy)
+                   closeOnDestroy, closeWhenDone)
 
 proc sb_destroy(ctx: var Switchboard, free: bool) {.sb.}
 


### PR DESCRIPTION
the issue we are trying to solve is:

```
echo foo | bar --stdin
```

If bar is reading its input from stdin, stdin needs to close
so that bar can proceed. If stdin is not closed, bar is hang
waiting for the stdin.

In libc if stdin is closed we get a `read()` output of 0
after a read which returned some data:

```
read("foo\n") -> 4
read("") -> 0 // as stdin closed
```

if the stdin is not closed, the second read will hang forever
as it will wait for the stdin to close

What the fix does here is that when it sees a read() returning 0
it passes that indication to all the subscribers to let them know
that the write FD should be closed to mimick what we got on the input
side of the switchboard.

Also it fixes some mixed whitespace as things werent rendering well
in vim.