### PR TITLE
ci: add tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
             arch: x86_64
 
           - os: macos
-            runs-on: macos-12
-            arch: x86_64
+            runs-on: macos-14
+            arch: arm64
 
     name: "${{ matrix.os }}-${{ matrix.arch }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           version: "binary:2.0.0"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Avoid rate limiting.
+          GITHUB_TOKEN: ${{ github.token }} # Avoid rate limiting.
 
       - name: Install Nimble dependencies
         run: nimble --accept install --depsOnly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runs-on: ubuntu-22.04
+            arch: x86_64
+
+          - os: macos
+            runs-on: macos-12
+            arch: x86_64
+
+    name: "${{ matrix.os }}-${{ matrix.arch }}"
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install Nim
+        uses: iffy/install-nim@049e1fad22d41813c77cff11ab8e1541a872014a
+        with:
+          version: "binary:2.0.0"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Avoid rate limiting.
+
+      - name: Install Nimble dependencies
+        run: nimble --accept install --depsOnly
+
+      - name: Build
+        run: nimble build # Trigger `before build` task to install headers.
+
+      - name: Run tests
+        run: nimble test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,6 @@ jobs:
             runs-on: ubuntu-22.04
             arch: x86_64
 
-          - os: macos
-            runs-on: macos-14
-            arch: arm64
-
     name: "${{ matrix.os }}-${{ matrix.arch }}"
     runs-on: ${{ matrix.runs-on }}
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -182,7 +182,11 @@ suite "misc":
     check resolvePath("~") == (if home[^1] == '/': home[0 ..< ^1] else: home)
     check resolvePath("") == getCurrentDir()
     check resolvePath("~fred") == joinPath(base, "fred")
-    check resolvePath("../../src/../../eoeoeo") == "/Users/eoeoeo"
+
+    const
+      expectedDir = currentSourcePath() / ".." / ".." / ".." / ".." / ".."
+
+    check resolvePath("../../src/../../eoeoeo") == expectedDir / "eoeoeo"
   test "random":
     let
       words = getRandomWords(3)


### PR DESCRIPTION
Let's just add Linux x86_64 for now, because:

- macOS x86_64 fails due to missing libffi
- macOS arm64 fails due to missing binary build for Nim 2.0.0

Closes: https://github.com/crashappsec/nimutils/issues/49