### PR TITLE
tests: resolvePath: fix macOS-only test

### DIFF
--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -182,7 +182,11 @@ suite "misc":
     check resolvePath("~") == (if home[^1] == '/': home[0 ..< ^1] else: home)
     check resolvePath("") == getCurrentDir()
     check resolvePath("~fred") == joinPath(base, "fred")
-    check resolvePath("../../src/../../eoeoeo") == "/Users/eoeoeo"
+
+    const
+      expectedDir = currentSourcePath() / ".." / ".." / ".." / ".." / ".."
+
+    check resolvePath("../../src/../../eoeoeo") == expectedDir / "eoeoeo"
   test "random":
     let
       words = getRandomWords(3)


### PR DESCRIPTION
This test would fail on Linux. In the GitHub Actions environment, it failed with:

```text
  /home/runner/work/nimutils/nimutils/tests/tests.nim(185, 48): Check failed:
  resolvePath("../../src/../../eoeoeo") == "/Users/eoeoeo"
  resolvePath("../../src/../../eoeoeo") was /home/runner/eoeoeo
[FAILED] path
```

Make the test more portable.

Fixes: https://github.com/crashappsec/nimutils/issues/50

---

I haven't tried to figure out the motivation for this particular test case - I just did the simple thing. This commit makes CI pass in https://github.com/crashappsec/nimutils/pull/52, which adds a workflow for tests in nimutils.