### PR TITLE
.github: make lint workflow run on push and dispatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
 name: lint
 
-on: pull_request
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Previously, this workflow ran only on pull request.

Closes: https://github.com/crashappsec/nimutils/issues/51