### PR TITLE
rope_htmlrender: fix some HTML rendering bugs

### DIFF
--- a/nimutils/rope_htmlrender.nim
+++ b/nimutils/rope_htmlrender.nim
@@ -5,7 +5,7 @@ const tagsToConvert = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "td", "th",
 import unicode, rope_base, strutils
 
 proc element(name, contents: string): string =
-  result = "\n<" & name & ">\n" & contents & "</" & name & ">\n"
+  result = "\n<" & name & ">\n" & contents & "\n</" & name & ">\n"
 
 proc nobreak(name, contents: string): string =
   result = "<" & name & ">" & contents  & "</" & name & ">"
@@ -69,17 +69,16 @@ proc toHtml*(r: Rope, indent = 0): string =
     else:
       caption = element("caption", caption)
 
-    result = element("table", thead & tbody & tfoot & caption)
+    result = nobreak("table", thead & tbody & tfoot & caption)
 
   of RopeTableRows:
-    var rows: seq[string]
+    result = ""
     if r.cells.len() != 0:
       for item in r.cells:
-        rows.add(item.toHtml())
-      result = rows.join("\n")
+        result.add(item.toHtml())
 
   of RopeTableRow:
-    var cells: seq[string]
+    var cells = ""
     if r.cells.len() != 0:
       for item in r.cells:
         var cell = item.toHtml()
@@ -88,7 +87,7 @@ proc toHtml*(r: Rope, indent = 0): string =
           cells.add(cell)
         else:
           cells.add(element("td", cell))
-      result = element("tr", cells.join("\n"))
+      result = element("tr", cells)
 
   for item in r.siblings:
     result &= item.toHtml()

--- a/nimutils/rope_htmlrender.nim
+++ b/nimutils/rope_htmlrender.nim
@@ -83,11 +83,12 @@ proc toHtml*(r: Rope, indent = 0): string =
     if r.cells.len() != 0:
       for item in r.cells:
         var cell = item.toHtml()
-        if cell.startswith("<td>") or cell.startswith("<th>"):
+        let i = cell.find('<')
+        if cell.continuesWith("<td>", i) or cell.continuesWith("<th>", i):
           cells.add(cell)
         else:
           cells.add(element("td", cell))
-      result = cells.join("\n")
+      result = element("tr", cells.join("\n"))
 
   for item in r.siblings:
     result &= item.toHtml()

--- a/nimutils/rope_htmlrender.nim
+++ b/nimutils/rope_htmlrender.nim
@@ -67,7 +67,9 @@ proc toHtml*(r: Rope, indent = 0): string =
       caption = element("caption", title)
       title   = ""
     elif caption != "":
-      caption = element("caption", caption)
+      let i = caption.find('<')
+      if not caption.continuesWith("<caption>", i):
+        caption = element("caption", caption)
 
     result = nobreak("table", caption & thead & tbody & tfoot)
 

--- a/nimutils/rope_htmlrender.nim
+++ b/nimutils/rope_htmlrender.nim
@@ -66,7 +66,7 @@ proc toHtml*(r: Rope, indent = 0): string =
     elif title != "":
       caption = element("caption", title)
       title   = ""
-    else:
+    elif caption != "":
       caption = element("caption", caption)
 
     result = nobreak("table", thead & tbody & tfoot & caption)

--- a/nimutils/rope_htmlrender.nim
+++ b/nimutils/rope_htmlrender.nim
@@ -48,18 +48,18 @@ proc toHtml*(r: Rope, indent = 0): string =
     result = r.toColor.toHtml()
 
   of RopeTable:
-    var title, thead, tbody, tfoot, caption : string
+    var title, caption, thead, tbody, tfoot: string
 
+    if r.title != nil:
+      title = r.title.toHtml()
+    if r.caption != nil:
+      caption = r.caption.toHtml()
     if r.thead != nil:
       thead = element("thead", r.thead.toHtml())
     if r.tbody != nil:
       tbody = element("tbody", r.tbody.toHtml())
     if r.tfoot != nil:
       tfoot = element("tfoot", r.tfoot.toHtml())
-    if r.title != nil:
-      title = r.title.toHtml()
-    if r.caption != nil:
-      caption = r.caption.toHtml()
 
     if title != "" and caption != "":
       title = element("h2", title)
@@ -69,7 +69,7 @@ proc toHtml*(r: Rope, indent = 0): string =
     elif caption != "":
       caption = element("caption", caption)
 
-    result = nobreak("table", thead & tbody & tfoot & caption)
+    result = nobreak("table", caption & thead & tbody & tfoot)
 
   of RopeTableRows:
     result = ""

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -215,6 +215,7 @@ suite "ropes":
   test "rope_htmlrender":
     const s = """
       <table>
+        <caption>Commands</caption>
         <tbody>
           <tr>
             <th>Command Name</th>
@@ -237,6 +238,10 @@ suite "ropes":
 
       <div>
       <table>
+      <caption>
+      Commands
+      </caption>
+
       <tbody>
 
       <tr>

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -232,4 +232,56 @@ suite "ropes":
       </table>
     """.dedent()
     let rope = s.htmlStringToRope()
-    check rope.toHtml() == s
+
+    const expected = """
+
+      <div>
+      <table>
+      <tbody>
+
+      <tr>
+
+      <th>
+      Command Name
+      </th>
+
+      <th>
+      Description
+      </th>
+
+      </tr>
+
+      <tr>
+
+      <td>
+      insert
+      </td>
+
+      <td>
+      Add chalk marks to artifacts
+      </td>
+
+      </tr>
+
+      <tr>
+
+      <td>
+      docgen
+      </td>
+
+      <td>
+      Generate technical documentation
+      </td>
+
+      </tr>
+
+      </tbody>
+      </table>
+      <div>
+
+      </div>
+
+      </div>
+    """.unindent()
+
+    check rope.toHtml() == expected

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -6,9 +6,12 @@ import nimutils/box
 import nimutils/unicodeid
 import nimutils/randwords # large code size, not imported by default.
 import nimutils/either    # Not working well, not import by default.
+import nimutils/rope_construct
+import nimutils/rope_htmlrender
 import tables
 import json
 import os
+import strutils
 
 proc removeSpaces(s: string): string =
   for c in s:
@@ -207,3 +210,26 @@ suite "misc":
     y = flatten[int](x)
     check y == @[1,2,3,4,5,6,7,8,9,10,11,12]
     check not compiles(y = flatten[int](z))
+
+suite "ropes":
+  test "rope_htmlrender":
+    const s = """
+      <table>
+        <tbody>
+          <tr>
+            <th>Command Name</th>
+            <th>Description</th>
+          </tr>
+          <tr>
+            <td>insert</td>
+            <td>Add chalk marks to artifacts</td>
+          </tr>
+          <tr>
+            <td>docgen</td>
+            <td>Generate technical documentation</td>
+          </tr>
+        </tbody>
+      </table>
+    """.dedent()
+    let rope = s.htmlStringToRope()
+    check rope.toHtml() == s


### PR DESCRIPTION
Fixes https://github.com/crashappsec/chalk/issues/178.

Consider this HTML:

```html
<table>
  <caption>Commands</caption>
  <tbody>
    <tr>
      <th>Command Name</th>
      <th>Description</th>
    </tr>
    <tr>
      <td>insert</td>
      <td>Add chalk marks to artifacts</td>
    </tr>
    <tr>
      <td>docgen</td>
      <td>Generate technical documentation</td>
    </tr>
  </tbody>
</table>
```

Before this PR, if we converted that to a `Rope` then called `toHtml`, we'd get invalid HTML:

```html
<div>

<table>

<tbody>

<td>

<th>
Command Name</th>
</td>


<td>

<th>
Description</th>
</td>


<td>

<td>
insert</td>
</td>


<td>

<td>
Add chalk marks to artifacts</td>
</td>


<td>

<td>
docgen</td>
</td>


<td>

<td>
Generate technical documentation</td>
</td>
</tbody>

<caption>

<caption>
Commands</caption>
</caption>
</table>

<div>
</div>
</div>
```

The errors:

- an extra `<td>` pair around each cell
- no `<tr>` anywhere
- `<caption>` at the bottom, but `<caption>` **must** be the first child of `<table>`

See the errors when pasting into https://validator.w3.org/#validate_by_input.

With this PR, `toHtml` produces valid HTML for that input:

```html
<div>
<table>
<caption>
Commands
</caption>

<tbody>

<tr>

<th>
Command Name
</th>

<th>
Description
</th>

</tr>

<tr>

<td>
insert
</td>

<td>
Add chalk marks to artifacts
</td>

</tr>

<tr>

<td>
docgen
</td>

<td>
Generate technical documentation
</td>

</tr>

</tbody>
</table>
<div>

</div>

</div>
```

which prettifies to something that's the same as the input, except:

```diff
+<div>
   <table>
     <caption>Commands</caption>
     <tbody>
       <tr>
         <th>Command Name</th>
         <th>Description</th>
       </tr>
       <tr>
         <td>insert</td>
         <td>Add chalk marks to artifacts</td>
       </tr>
       <tr>
         <td>docgen</td>
         <td>Generate technical documentation</td>
       </tr>
     </tbody>
   </table>
+  <div></div>
+</div>
```