### PR TITLE
ending switchboard loop when select returns 0

### DIFF
--- a/nimutils/c/switchboard.c
+++ b/nimutils/c/switchboard.c
@@ -1603,8 +1603,10 @@ sb_operate_switchboard(switchboard_t *ctx, bool loop)
         if (ctx->fds_ready > 0) {
             handle_ready_reads(ctx);
             handle_ready_writes(ctx);
+        }
+        if (ctx->fds_ready >= 0) {
             handle_loop_end(ctx);
-        } else if (ctx->fds_ready == -1) {
+        } else {
             // select returned error
             if (errno == EINTR) {
                 continue;


### PR DESCRIPTION
this happens when subprocess doesnt do much IO and so subprocess completes even though it has no ready FDs so we should finish loop even when its ==0 vs previously it was only accounting for >0

note that we still only handle ready writes/reads when select returns >0 as there is no point in handling FDs when they have nothing ready yet