### PR TITLE
fix(s3client, stsclient): add timeout parameter for newHttpClient

### DIFF
--- a/nimutils/s3client.nim
+++ b/nimutils/s3client.nim
@@ -26,11 +26,11 @@ type
     size*: int
 
 proc newS3Client*(creds: AwsCredentials, region: string = defaultRegion,
-    host: string = awsURI): S3Client =
+    host: string = awsURI, timeoutMilliseconds = 1000): S3Client =
   let
     # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
     httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ",
-        "-").toLower&"; darwin/16.7.0")
+        "-").toLower&"; darwin/16.7.0", timeout = timeoutMilliseconds)
     scope = AwsScope(date: getAmzDateString(), region: region, service: "s3")
 
   var

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -10,10 +10,12 @@ type
 
 proc newStsClient*(creds: AwsCredentials,
                    region: string = defaultRegion,
-                   host: string = awsURI): StsClient =
+                   host: string = awsURI,
+                   timeoutMilliseconds = 1000): StsClient =
   let
     # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
-    httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ", "-").toLower&"; darwin/16.7.0")
+    httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ", "-").toLower&"; darwin/16.7.0",
+                               timeout = timeoutMilliseconds)
     scope = AwsScope(date: getAmzDateString(), region: region, service: "sts")
 
   var


### PR DESCRIPTION
Add missing `timeout` parameters in s3client and stsclient. It previously used the default value, [which is -1](https://github.com/nim-lang/Nim/blob/a488067a4130f029000be4550a0fb1b39e0e9e7c/lib/pure/httpclient.nim#L601-L603).

I looked at `net.nim` again, and still didn't see an obvious reason for why timeouts wouldn't be honored there. Was the problem in `net.nim`, or was it due to the missing `timeout` params here?