### PR TITLE
style: improve formatting of string concatenation

### DIFF
--- a/nimutils/awsclient.nim
+++ b/nimutils/awsclient.nim
@@ -98,7 +98,7 @@ proc newAwsClient*(creds: AwsCredentials, region,
   let
     # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
     httpclient = createHttpClient(
-      userAgent = "nimaws-sdk/0.3.3; "&defUserAgent.replace(" ", "-").toLower&"; darwin/16.7.0",
+      userAgent = "nimaws-sdk/0.3.3; " & defUserAgent.replace(" ", "-").toLower() & "; darwin/16.7.0",
     )
     scope = AwsScope(date: getAmzDateString(), region: region, service: service)
 

--- a/nimutils/s3client.nim
+++ b/nimutils/s3client.nim
@@ -29,8 +29,10 @@ proc newS3Client*(creds: AwsCredentials, region: string = defaultRegion,
     host: string = awsURI, timeoutMilliseconds = 1000): S3Client =
   let
     # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
-    httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ",
-        "-").toLower&"; darwin/16.7.0", timeout = timeoutMilliseconds)
+    httpclient = newHttpClient(
+      "nimaws-sdk/0.3.3; " & defUserAgent.replace(" ", "-").toLower() & "; darwin/16.7.0",
+      timeout = timeoutMilliseconds,
+    )
     scope = AwsScope(date: getAmzDateString(), region: region, service: "s3")
 
   var

--- a/nimutils/s3client.nim
+++ b/nimutils/s3client.nim
@@ -42,7 +42,7 @@ proc newS3Client*(creds: AwsCredentials, region: string = defaultRegion,
   if mhost.len > 0:
     if mhost.find("http") == -1:
       echo "host should be a valid URI assuming http://"
-      mhost = "http://"&host
+      mhost = "http://" & host
   else:
     mhost = awsURI
   endpoint = parseUri(mhost)

--- a/nimutils/sigv4.nim
+++ b/nimutils/sigv4.nim
@@ -31,7 +31,7 @@ const
 
 # Some convenience operators, for fun and aesthetics
 proc `$`(s: AwsScope): string =
-  return s.date[0..7]&"/"&s.region&"/"&s.service
+  return s.date[0..7] & "/" & s.region & "/" & s.service
 
 proc `!$`(s: string): string =
   return sha256Hex(s)
@@ -153,8 +153,8 @@ proc create_signature*(key: string, sts: string): string =
 proc create_signing_key*(secret: string, scope: AwsScope,
     termination: string = term): string =
   # (a ?$ b) => $hmac_sha256(a,b)
-  return ("AWS4"&secret) ?$ scope.date[0..7] ?$ scope.region ?$ scope.service ?$ termination
-  # ? cleaner than $hmac_sha256($hmac_sha256($hmac_sha256($hmac_sha256("AWS4"&secret, date[0..7]),region),service),termination) ?
+  return ("AWS4" & secret) ?$ scope.date[0..7] ?$ scope.region ?$ scope.service ?$ termination
+  # ? cleaner than $hmac_sha256($hmac_sha256($hmac_sha256($hmac_sha256("AWS4" & secret, date[0..7]),region),service),termination) ?
 
 proc create_authorization_header*(id: string, scope: AwsScope,
     signed_head: string, sig: string, opts: (string, string) = (alg,

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -14,8 +14,10 @@ proc newStsClient*(creds: AwsCredentials,
                    timeoutMilliseconds = 1000): StsClient =
   let
     # TODO - use some kind of template and compile-time variable to put the correct kernel used to build the sdk in the UA?
-    httpclient = newHttpClient("nimaws-sdk/0.3.3; "&defUserAgent.replace(" ", "-").toLower&"; darwin/16.7.0",
-                               timeout = timeoutMilliseconds)
+    httpclient = newHttpClient(
+      "nimaws-sdk/0.3.3; " & defUserAgent.replace(" ", "-").toLower() & "; darwin/16.7.0",
+      timeout = timeoutMilliseconds,
+    )
     scope = AwsScope(date: getAmzDateString(), region: region, service: "sts")
 
   var

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -27,7 +27,7 @@ proc newStsClient*(creds: AwsCredentials,
   if mhost.len > 0:
     if mhost.find("http") == -1:
       echo "host should be a valid URI assuming http://"
-      mhost = "http://"&host
+      mhost = "http://" & host
   else:
     mhost = awsURI
   endpoint = parseUri(mhost)


### PR DESCRIPTION
The lack of spaces around `&` here made these harder to read.

My first reading of:

```nim
&"
```

is the beginning of a [strformat][1] format string, like:

```nim
import std/strformat

const msg = "hello"
doAssert &"{msg}\n" == "hello\n"
```

 Let's write:

```nim
& "
```

to clarify that we're doing string concatenation.

Also reformat a little and change `.toLower` to `.toLower()` while we're here, since using parens to distinguish calls from field accesses seems to be our style.

[1]: https://nim-lang.org/docs/strformat.html