### PR TITLE
refactor: improve robustness and clarity of Nim imports

### DIFF
--- a/nimutils.nim
+++ b/nimutils.nim
@@ -11,12 +11,12 @@
 ## few fixes have all been for compatability and are made under the
 ## same license. I also migrated the crypto to openssl.
 
-import nimutils/[box, random, unicodeid, pubsub, sinks, auth, misc, texttable],
-       nimutils/[file, filetable, encodings, advisory_lock, progress],
-       nimutils/[sha, aes, prp, hexdump, markdown, htmlparse, net, colortable],
-       nimutils/[rope_base, rope_styles, rope_construct, rope_prerender],
-       nimutils/[rope_ansirender, rope_htmlrender, rope_textrender],
-       nimutils/[switchboard, subproc, int128_t, dict, list, c4str]
+import nimutils/[box, random, unicodeid, pubsub, sinks, auth, misc, texttable,
+                 file, filetable, encodings, advisory_lock, progress,
+                 sha, aes, prp, hexdump, markdown, htmlparse, net, colortable,
+                 rope_base, rope_styles, rope_construct, rope_prerender,
+                 rope_ansirender, rope_htmlrender, rope_textrender,
+                 switchboard, subproc, int128_t, dict, list, c4str]
 export box, random, unicodeid, pubsub, sinks, auth, misc, random, texttable,
        file, filetable, encodings, advisory_lock, progress, sha,
        aes, prp, hexdump, markdown, htmlparse, net, colortable, rope_base,
@@ -38,7 +38,7 @@ when defined(macosx):
 ##              isn't worth it if you're not using it.
 
 when isMainModule:
-  import tables, streams, algorithm, strutils
+  import std/[tables, streams, algorithm, strutils]
   useCrashTheme()
 
   when defined(macosx):
@@ -134,7 +134,7 @@ when isMainModule:
     echo "Here it is, boxed, as Json: ", boxToJson(dictBox)
 
     # This shouldn't work w/o a custom handler.
-    # import sugar
+    # import std/sugar
     # var v: ()->int
     # unpack[()->int](b123, v)
 

--- a/nimutils/advisory_lock.nim
+++ b/nimutils/advisory_lock.nim
@@ -1,8 +1,8 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import os, file, posix, misc, subproc
-
+import std/[os, posix]
+import "."/[file, misc, subproc]
 
 proc flock*(fd: cint, flags: cint): cint {.discardable, importc,
                                            header: "<sys/file.h>".}

--- a/nimutils/aes.nim
+++ b/nimutils/aes.nim
@@ -1,4 +1,5 @@
-import random, openssl, options
+import std/[openssl, options]
+import "."/random
 
 const badNonceError =  "GCM nonces should be exactly 12 bytes. If " &
                        "you want more, consider SHA256-hashing it, and " &

--- a/nimutils/auth.nim
+++ b/nimutils/auth.nim
@@ -7,8 +7,8 @@
 ## * basic auth
 ## * JWT
 
-import options, sugar, tables, std/[base64, httpclient, times]
-import jwt
+import std/[options, sugar, tables, base64, httpclient, times]
+import "."/jwt
 
 type
   AuthParams *      = OrderedTableRef[string, string]

--- a/nimutils/awsclient.nim
+++ b/nimutils/awsclient.nim
@@ -13,10 +13,9 @@
     * a request proc which takes an AwsClient and the request params to handle Sigv4 signing and async dispatch
  ]#
 
-import times, tables, unicode, uri, std/envvars
-import strutils except toLower
-import httpclient
-import sigv4, net
+import std/[times, tables, unicode, uri, envvars, httpclient]
+import std/strutils except toLower
+import "."/[sigv4, net]
 
 export sigv4.AwsCredentials, sigv4.AwsScope
 

--- a/nimutils/box.nim
+++ b/nimutils/box.nim
@@ -55,11 +55,7 @@
 ## * so beware!                                                       *
 ## ********************************************************************
 
-import std/typetraits
-import std/hashes
-import strutils
-import tables
-import json
+import std/[typetraits, hashes, strutils, tables, json]
 
 type
     MixedKind* = enum

--- a/nimutils/c4str.nim
+++ b/nimutils/c4str.nim
@@ -1,4 +1,4 @@
-import os
+import std/os
 
 static:
   {.compile: joinPath(splitPath(currentSourcePath()).head, "c/strcontainer.c").}

--- a/nimutils/colortable.nim
+++ b/nimutils/colortable.nim
@@ -1,6 +1,6 @@
 # Taken from:HTML color list as found at:
 # https://en.wikipedia.org/wiki/Web_colors
-import tables, os, parseUtils
+import std/[tables, os, parseutils]
 
 ## This array contains all names we recognize for full 24-bit color.
 ## APIs that accept color names will also accept #abc123 style hex

--- a/nimutils/crownhash.nim
+++ b/nimutils/crownhash.nim
@@ -57,7 +57,7 @@
 ## from Nim, and currently ignore otherwise.
 
 
-import sugar, os, macros, options
+import std/[sugar, os, macros, options]
 
 {.pragma: hatc, cdecl, importc.}
 

--- a/nimutils/dict.nim
+++ b/nimutils/dict.nim
@@ -2,5 +2,5 @@
 ## multiplex the Dict interface statically, depending on whether or
 ## not threads are used.
 when compileOption("threads"):
-  import crownhash
+  import "."/crownhash
   export crownhash

--- a/nimutils/either.nim
+++ b/nimutils/either.nim
@@ -6,7 +6,7 @@
 ## haven't removed it is because there is code in Con4m that is still
 ## using it for the time being.
 
-import macros
+import std/macros
 
 type
   Either*[T, U] = object

--- a/nimutils/encodings.nim
+++ b/nimutils/encodings.nim
@@ -1,7 +1,8 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import misc, tables, random, macros
+import std/[tables, macros]
+import "."/[misc, random]
 
 const goodB32Map    = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
                        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K',

--- a/nimutils/file.nim
+++ b/nimutils/file.nim
@@ -1,7 +1,7 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import os, posix, strutils, posix_utils
+import std/[os, posix, strutils, posix_utils]
 
 when hostOs == "macosx":
   {.emit: """

--- a/nimutils/filetable.nim
+++ b/nimutils/filetable.nim
@@ -9,7 +9,7 @@
 ## :Copyright: 2022, 2023, Crash Override, Inc.
 
 
-import tables, strutils, os
+import std/[tables, strutils, os]
 
 type
   FileTable*        = Table[string, string]

--- a/nimutils/hexdump.nim
+++ b/nimutils/hexdump.nim
@@ -4,7 +4,7 @@
 ## only way I could make Nim happy was if I changed them to `unsigned
 ## int`, which is okay on all the machines I care about anyway.
 
-import strutils, os
+import std/[strutils, os]
 
 static:
   {.compile: joinPath(splitPath(currentSourcePath()).head, "c/hex.c").}

--- a/nimutils/htmlparse.nim
+++ b/nimutils/htmlparse.nim
@@ -4,7 +4,7 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2022 - 2023, Crash Override, Inc.
 
-import tables, strutils, unicode
+import std/[tables, strutils, unicode]
 
 type
   HtmlNodeType* = enum

--- a/nimutils/jwt.nim
+++ b/nimutils/jwt.nim
@@ -2,7 +2,7 @@
 ## For now it extracts json paylods from JWT tokens as well
 ## has utility methods for checking if JWT token has expired
 
-import strutils, std/[base64, json, times]
+import std/[strutils, base64, json, times]
 
 type
   JwtHeader* = ref object

--- a/nimutils/lfarray.nim
+++ b/nimutils/lfarray.nim
@@ -1,4 +1,4 @@
-import options
+import std/options
 
 {.pragma: hatc, cdecl, importc.}
 

--- a/nimutils/list.nim
+++ b/nimutils/list.nim
@@ -1,3 +1,3 @@
 when compileOption("threads"):
-  import lfarray
+  import "."/lfarray
   export lfarray

--- a/nimutils/logging.nim
+++ b/nimutils/logging.nim
@@ -1,8 +1,8 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import tables, options, pubsub, sinks, rope_base, rope_construct,
-   rope_ansirender, rope_styles
+import std/[tables, options]
+import "."/[pubsub, sinks, rope_base, rope_construct, rope_ansirender, rope_styles]
 
 type LogLevel* = enum
   ## LogLevel describes what kind of messages you want to see.

--- a/nimutils/macproc.nim
+++ b/nimutils/macproc.nim
@@ -2,7 +2,7 @@ when not defined(macosx):
   static:
     error "macproc.nim only loads on macos"
 
-import os, posix
+import std/[os, posix]
 
 {.compile: joinPath(splitPath(currentSourcePath()).head, "c/macproc.c").}
 

--- a/nimutils/managedtmp.nim
+++ b/nimutils/managedtmp.nim
@@ -1,7 +1,7 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import std/tempfiles, streams, sugar, os
+import std/[tempfiles, streams, sugar, os]
 
 type OnExitTmpFileCallback = (seq[string], seq[string], seq[string]) -> void
 

--- a/nimutils/markdown.nim
+++ b/nimutils/markdown.nim
@@ -5,7 +5,7 @@
 
 
 
-import random
+import "."/random
 
 {.emit: """#include "md4c.h" """.}
 

--- a/nimutils/misc.nim
+++ b/nimutils/misc.nim
@@ -1,9 +1,9 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2022-2023, Crash Override, Inc.
 
-import macros, times, os, posix
+import std/[macros, times, os, posix]
 # The name flatten conflicts with a method in the options module.
-from options import get, Option, isSome, isNone
+from std/options import get, Option, isSome, isNone
 export get, Option, isSome, isNone
 
 template unreachable*() =

--- a/nimutils/net.nim
+++ b/nimutils/net.nim
@@ -1,6 +1,5 @@
-import std/[asyncfutures, net, httpclient, uri, math, os, streams, strutils]
-import openssl
-import ./managedtmp
+import std/[asyncfutures, net, httpclient, uri, math, os, streams, strutils, openssl]
+import "."/managedtmp
 
 proc getRootCAStoreContent(): string =
   const

--- a/nimutils/nimscript.nim
+++ b/nimutils/nimscript.nim
@@ -1,4 +1,4 @@
-import os, strutils
+import std/[os, strutils]
 export os, strutils
 
 var

--- a/nimutils/private/codegen/genrandom.nim
+++ b/nimutils/private/codegen/genrandom.nim
@@ -13,12 +13,7 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2022
 
-import streams
-import tables
-import strutils
-import strformat
-import std/sysrand
-import algorithm
+import std/[streams, tables, strutils, strformat, sysrand, algorithm]
 
 const
   fullFileName = "2of12full.txt"
@@ -221,11 +216,7 @@ when isMainModule:
 
 
   let outstr = fmt"""
-import std/sysrand
-import strutils
-import strformat
-import algorithm
-import options
+import std/[sysrand, strutils, strformat, algorithm, options]
 
 template secureRand*[T](): T =
   ## Returns a uniformly distributed random value of any _sized_ type.

--- a/nimutils/private/s3_get_object.nim
+++ b/nimutils/private/s3_get_object.nim
@@ -2,8 +2,8 @@
   Simple example of using a nim S3Client to get an object from an S3 bucket
 ]#
 
-import os, tables, times, math, asyncdispatch, httpclient
-import ../s3client
+import std/[os, tables, times, math, asyncdispatch, httpclient]
+import ".."/s3client
 
 if not existsEnv("AWS_ACCESS_ID") or not existsEnv("AWS_ACCESS_SECRET"):
   quit("No credentials found in environment.")

--- a/nimutils/private/s3_list_buckets.nim
+++ b/nimutils/private/s3_list_buckets.nim
@@ -2,8 +2,8 @@
   Simple example of using a nim S3Client to get a list of S3 buckets
 ]#
 
-import os, tables, times, math, asyncdispatch, httpclient
-import ../s3client
+import std/[os, tables, times, math, asyncdispatch, httpclient]
+import ".."/s3client
 
 if not existsEnv("AWS_ACCESS_ID") or not existsEnv("AWS_ACCESS_SECRET"):
   quit("No credentials found in environment.")

--- a/nimutils/private/s3_list_objects.nim
+++ b/nimutils/private/s3_list_objects.nim
@@ -2,8 +2,8 @@
   Simple example of using a nim S3Client to get a list of objects from an S3 bucket
 ]#
 
-import os, tables, times, math, asyncdispatch, httpclient
-import ../s3client
+import std/[os, tables, times, math, asyncdispatch, httpclient]
+import ".."/s3client
 
 if not existsEnv("AWS_ACCESS_ID") or not existsEnv("AWS_ACCESS_SECRET"):
   quit("No credentials found in environment.")

--- a/nimutils/private/s3_put_object.nim
+++ b/nimutils/private/s3_put_object.nim
@@ -2,9 +2,8 @@
   Simple example of using a nim S3Client to put an object into an S3 bucket
 ]#
 
-import os, tables, times, math, asyncdispatch, httpclient
-import streams
-import ../s3client
+import std/[os, tables, times, math, asyncdispatch, httpclient, streams]
+import ".."/s3client
 
 if not existsEnv("AWS_ACCESS_ID") or not existsEnv("AWS_ACCESS_SECRET"):
   quit("No credentials found in environment.")

--- a/nimutils/progress.nim
+++ b/nimutils/progress.nim
@@ -1,4 +1,5 @@
-import misc, sugar, rope_ansirender, rope_styles, terminal, strformat, unicode
+import std/[sugar, terminal, strformat, unicode]
+import "."/[misc, rope_ansirender, rope_styles]
 
 type
   ProgressWinchCb = () -> bool

--- a/nimutils/prp.nim
+++ b/nimutils/prp.nim
@@ -39,7 +39,7 @@
 ## and 'decrypt', we use reversed (horizontally) and mirrored names...
 ## `brb` seems like a good function name for decryption.
 
-import aes, sha, random
+import "."/[aes, sha, random]
 
 
 type PrpCtx = object

--- a/nimutils/pubsub.nim
+++ b/nimutils/pubsub.nim
@@ -6,8 +6,8 @@
 ## probably should be updated / merged with the lower level IO
 ## multiplexing switchboard that is now part of the library.
 
-import tables, sugar, options, json, strutils, std/terminal, unicodeid,
-       rope_ansirender, rope_construct, std/httpclient, auth, algorithm
+import std/[tables, sugar, options, json, strutils, terminal, httpclient, algorithm]
+import "."/[unicodeid, rope_ansirender, rope_construct, auth]
 
 type
   InitCallback*   = ((SinkConfig) -> bool)

--- a/nimutils/random.nim
+++ b/nimutils/random.nim
@@ -1,7 +1,8 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2022, 2023, Crash Override, Inc.
 
-import std/sysrand, openssl, misc
+import std/[sysrand, openssl]
+import "."/misc
 
 # This used to be in here.
 export bytesToString

--- a/nimutils/randwords.nim
+++ b/nimutils/randwords.nim
@@ -1,7 +1,8 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import strutils, algorithm, misc, options, random
+import std/[strutils, algorithm, options]
+import "."/[misc, random]
 
 const binDict = ["aardvark", "abaci", "aback", "abacus", "abaft", "abalone",
     "abandon", "abandoned", "abandonment", "abase", "abasement", "abash",

--- a/nimutils/rope_ansirender.nim
+++ b/nimutils/rope_ansirender.nim
@@ -1,10 +1,9 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import options, unicode, misc, colortable, rope_construct, rope_base,
-       rope_prerender, rope_styles
-
-from strutils import join, endswith
+import std/[options, unicode]
+from std/strutils import join, endswith
+import "."/[misc, colortable, rope_construct, rope_base, rope_prerender, rope_styles]
 
 template ansiReset(): string = "\e[0m"
 

--- a/nimutils/rope_base.nim
+++ b/nimutils/rope_base.nim
@@ -1,5 +1,6 @@
-import unicode, options, unicodeid, unicodedb/properties, misc, strutils,
-       random, hexdump, tables
+import std/[unicode, options, strutils, tables]
+import pkg/[unicodedb/properties]
+import "."/[unicodeid, misc, random, hexdump]
 
 
 const

--- a/nimutils/rope_construct.nim
+++ b/nimutils/rope_construct.nim
@@ -1,10 +1,9 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import  unicode, markdown, htmlparse, tables, parseutils, colortable, rope_base,
-        macros
-
-from strutils import startswith, replace
+import std/[unicode, tables, parseutils, macros]
+from std/strutils import startswith, replace
+import "."/[markdown, htmlparse, colortable, rope_base]
 
 var breakingStyles*: Table[string, bool] = {
     "container"  : true,

--- a/nimutils/rope_htmlrender.nim
+++ b/nimutils/rope_htmlrender.nim
@@ -2,7 +2,8 @@ const tagsToConvert = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "td", "th",
                        "em", "italic", "i", "u", "inverse", "underline",
                        "strong", "code", "caption", "pre"]
 
-import unicode, rope_base, strutils
+import std/[unicode, strutils]
+import "."/rope_base
 
 proc element(name, contents: string): string =
   result = "\n<" & name & ">\n" & contents & "</" & name & ">\n"

--- a/nimutils/rope_prerender.nim
+++ b/nimutils/rope_prerender.nim
@@ -7,8 +7,8 @@
 # Everything else on my original wishlist is here now though.
 
 
-import tables, options, std/terminal, rope_base, rope_construct, rope_styles,
-       unicodeid, unicode, misc
+import std/[tables, options, terminal, unicode]
+import "."/[rope_base, rope_construct, rope_styles, unicodeid, misc]
 
 type
   RenderBoxKind* = enum RbText, RbBoxes

--- a/nimutils/rope_styles.nim
+++ b/nimutils/rope_styles.nim
@@ -2,7 +2,8 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import unicode, tables, rope_base, rope_construct, options, strutils
+import std/[unicode, tables, options, strutils]
+import "."/[rope_base, rope_construct]
 
 let
   BoxStylePlain* =     BoxStyle(horizontal: Rune(0x2500),

--- a/nimutils/rope_textrender.nim
+++ b/nimutils/rope_textrender.nim
@@ -1,4 +1,5 @@
-import rope_base, rope_prerender, rope_construct, unicode
+import std/unicode
+import "."/[rope_base, rope_prerender, rope_construct]
 
 proc toUtf8*(r: Rope, width = high(int)): string =
   ## Convert a rope to UTF8 with no styling other than line wrap, if a

--- a/nimutils/s3client.nim
+++ b/nimutils/s3client.nim
@@ -4,9 +4,9 @@
   A simple object API for performing (limited) S3 operations
  ]#
 
-import strutils except toLower
-import times, unicode, tables, httpclient, xmlparser, xmltree, uri
-import awsclient
+import std/[times, unicode, tables, httpclient, xmlparser, xmltree, uri]
+import std/strutils except toLower
+import "."/awsclient
 export awsclient
 
 const

--- a/nimutils/sha.nim
+++ b/nimutils/sha.nim
@@ -1,4 +1,4 @@
-import openssl, strutils
+import std/[openssl, strutils]
 
 {.pragma: lcrypto, cdecl, dynlib: DLLUtilName, importc.}
 

--- a/nimutils/sigv4.nim
+++ b/nimutils/sigv4.nim
@@ -4,10 +4,11 @@
   Implements functions to handle the AWS Signature v4 request signing
   http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
  ]#
-import times, algorithm, tables, sha, re
-import strutils except toLower
-import unicode except strip
-from uri import parseUri
+import std/[times, algorithm, tables, re]
+import std/strutils except toLower
+import std/unicode except strip
+from std/uri import parseUri
+import "."/sha
 
 
 type

--- a/nimutils/sinks.nim
+++ b/nimutils/sinks.nim
@@ -1,9 +1,9 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import streams, tables, options, os, strutils, std/[net, uri, httpclient],
-       s3client, pubsub, misc, random, encodings, std/tempfiles,
-       parseutils, file, std/asyncfutures, net
+import std/[streams, tables, options, os, strutils, net, uri, httpclient,
+            tempfiles, parseutils, asyncfutures]
+import "."/[s3client, pubsub, misc, random, encodings, file, net]
 
 const defaultLogSearchPath = @["/var/log/", "~/.log/", "."]
 

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -1,5 +1,5 @@
-import httpclient, strutils, tables, times, uri, std/[json]
-import awsclient
+import std/[httpclient, strutils, tables, times, uri, json]
+import "."/awsclient
 export awsclient
 
 const

--- a/nimutils/subproc.nim
+++ b/nimutils/subproc.nim
@@ -1,4 +1,5 @@
-import switchboard, posix, random, os, file
+import std/[posix, os]
+import "."/[switchboard, random, file]
 
 {.warning[UnusedImport]: off.}
 {.compile: joinPath(splitPath(currentSourcePath()).head, "c/subproc.c").}

--- a/nimutils/switchboard.nim
+++ b/nimutils/switchboard.nim
@@ -41,7 +41,7 @@
 ## `subprocess` interface, though we will, in the not-too-distant
 ## future add a more polished interface to this module that would be
 ## appropriate for server setups, etc.
-import os, posix
+import std/[os, posix]
 
 {.pragma: sb, cdecl, importc, nodecl.}
 

--- a/nimutils/texttable.nim
+++ b/nimutils/texttable.nim
@@ -1,8 +1,8 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2023, Crash Override, Inc.
 
-import rope_base, rope_construct, rope_prerender, rope_styles, unicode,
-       unicodeid, std/terminal, tables, sugar
+import std/[unicode, terminal, tables, sugar]
+import "."/[rope_base, rope_construct, rope_prerender, rope_styles, unicodeid]
 
 proc instantTable*[T: string|Rope](cells: openarray[T], title = Rope(nil),
                                     caption = Rope(nil),

--- a/nimutils/unicodeid.nim
+++ b/nimutils/unicodeid.nim
@@ -5,8 +5,9 @@
 ## :Author: John Viega (john@crashoverride.com)
 ## :Copyright: 2022
 
-import streams, unicode, strutils, std/terminal, misc
-import unicodedb/properties, unicodedb/widths
+import std/[streams, unicode, strutils, terminal]
+import pkg/[unicodedb/properties, unicodedb/widths]
+import "."/misc
 
 const magicRune* = Rune(0x200b)
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,14 +1,11 @@
 ## Unit tests.
 
-import unittest
+import std/[unittest, tables, json, os]
 import nimutils
-import nimutils/box
-import nimutils/unicodeid
+import nimutils/[box, unicodeid]
 import nimutils/randwords # large code size, not imported by default.
-import nimutils/either    # Not working well, not import by default.
-import tables
-import json
-import os
+import nimutils/either    # Not working well, not imported by default.
+
 
 proc removeSpaces(s: string): string =
   for c in s:


### PR DESCRIPTION
Apply the same process from a recent chalk commit (https://github.com/crashappsec/chalk/commit/7fdaf52a276694e6686a8b2f7ee6148f1f4e7355), with the same rationale.

In particular, there was previously increased potential for confusion from:

```nim
import random
```

or

```nim
import net
```

which imported nimutils modules with the same names as Nim standard library modules (see [`std/random`][2] and [`std/net`][3]). For these I'd actually suggest going further and renaming those modules, but let's consider that for a later PR.

There was also:

```nim
import sha
```

which may be confused with the Nim stdlib modules, which are named `sha1`, `sha2`, and `sha3`.

[1]: https://github.com/crashappsec/chalk/commit/7fdaf52a2766
[2]: https://github.com/nim-lang/Nim/blob/v2.0.0/lib/pure/random.nim
[3]: https://github.com/nim-lang/Nim/blob/v2.0.0/lib/pure/net.nim


---

For me personally: consistent imports are helpful, and diffs like this are significant improvement in readability:

```diff
-import unicode, options, unicodeid, unicodedb/properties, misc, strutils,
-       random, hexdump, tables
+import std/[unicode, options, strutils, tables]
+import pkg/[unicodedb/properties]
+import "."/[unicodeid, misc, random, hexdump]
```

```diff
-import streams, tables, options, os, strutils, std/[net, uri, httpclient],
-       s3client, pubsub, misc, random, encodings, std/tempfiles,
-       parseutils, file, std/asyncfutures, net
+import std/[streams, tables, options, os, strutils, net, uri, httpclient,
+            tempfiles, parseutils, asyncfutures]
+import "."/[s3client, pubsub, misc, random, encodings, file, net]
```

(note also that both `std/net` and `"."/net` are imported here).