### PR TITLE
setting error exit code when exec* errors

### DIFF
--- a/nimutils/c/subproc.c
+++ b/nimutils/c/subproc.c
@@ -403,21 +403,18 @@ setup_subscriptions(subprocess_t *ctx, bool pty)
 static void
 subproc_do_exec(subprocess_t *ctx)
 {
-    int error;
     if (ctx->envp) {
-        error = execve(ctx->cmd, ctx->argv, ctx->envp);
+        execve(ctx->cmd, ctx->argv, ctx->envp);
     }
     else {
-        error = execv(ctx->cmd, ctx->argv);
+        execv(ctx->cmd, ctx->argv);
     }
-    if (error == -1) {
-        fprintf(stderr, "%s: %s\n",ctx->cmd, strerror(errno));
-        exit(1);
-    }
-
-    // If we get past the exec, kill the subproc, which will
-    // tear down the switchboard.
-    abort();
+    // If we get past the exec, kill the subproc with non-zero exit code,
+    // which will tear down the switchboard and print to stderr the
+    // errono description. For example for nonexisting command will be:
+    // foo: No such file or directory
+    fprintf(stderr, "%s: %s\n",ctx->cmd, strerror(errno));
+    exit(1);
 }
 
 party_t *

--- a/nimutils/c/subproc.c
+++ b/nimutils/c/subproc.c
@@ -403,12 +403,18 @@ setup_subscriptions(subprocess_t *ctx, bool pty)
 static void
 subproc_do_exec(subprocess_t *ctx)
 {
+    int error;
     if (ctx->envp) {
-        execve(ctx->cmd, ctx->argv, ctx->envp);
+        error = execve(ctx->cmd, ctx->argv, ctx->envp);
     }
     else {
-        execv(ctx->cmd, ctx->argv);
+        error = execv(ctx->cmd, ctx->argv);
     }
+    if (error == -1) {
+        fprintf(stderr, "%s: %s\n",ctx->cmd, strerror(errno));
+        exit(1);
+    }
+
     // If we get past the exec, kill the subproc, which will
     // tear down the switchboard.
     abort();

--- a/nimutils/c/subproc.c
+++ b/nimutils/c/subproc.c
@@ -414,6 +414,10 @@ subproc_do_exec(subprocess_t *ctx)
     // errono description. For example for nonexisting command will be:
     // foo: No such file or directory
     fprintf(stderr, "%s: %s\n",ctx->cmd, strerror(errno));
+    // TODO switch back to abort() once better event handling is implemented
+    // in switchboard to correctly detect exit code as otherwise waitpid()
+    // detects program has exited however not all signal handlers have executed
+    // hence exit code is unknown yet
     exit(1);
 }
 


### PR DESCRIPTION
otherwise when exec* would fail, its error is indicated by errno however no appropriate exit code would be set and the overall subprocess would be marked as successful with exit code of 0