### PR TITLE
gracefully handling resolvePath exception in findAllExePaths

### DIFF
--- a/nimutils/file.nim
+++ b/nimutils/file.nim
@@ -262,7 +262,12 @@ proc findAllExePaths*(cmdName:    string,
     allPaths   = @[tup.head] & allPaths
 
   for item in allPaths:
-    let path = resolvePath(item)
+    let path =
+      try:
+        resolvePath(item)
+      except:
+        # most likely running in limited env and cant resolve "~"
+        continue
     if me == targetName and path == mydir: continue # Don't ever find ourself.
     let potential = joinPath(path, targetName)
     if potential.isExecutable():


### PR DESCRIPTION
fixes chalk error:

```
Unhandled error when running builtin call: find_exeerror is: index out of bounds, the container is empty
    attestation_binary := find_exe("cosign", supplemental_path)
```