### PR TITLE
fix: resolve compiler errors from Nim 2.0.8

### DIFF
--- a/nimutils/advisory_lock.nim
+++ b/nimutils/advisory_lock.nim
@@ -35,7 +35,7 @@ proc obtainLockFile*(fname: string, writeLock = false, timeout: int64 = 5000,
                        ", Got error = " & $(strerror(errno)))
   var
     endtime: uint64 = if timeout < 0:
-                      0xffffffffffffffff
+                      high(uint64)
                     else:
                       unixTimeInMs() + uint64(timeout)
     sleepdur = 16

--- a/nimutils/aes.nim
+++ b/nimutils/aes.nim
@@ -159,10 +159,10 @@ proc get_keystream(ctx: pointer, outbuf: pointer, buflen: cint):
 proc run_ctr_mode(ctx, outbuf, inbuf: pointer, buflen: cint):
                        cint {.cdecl,importc.}
 
-proc `=destroy`*(ctx: AesCtx) =
+proc `=destroy`*(ctx: var AesCtx) =
     EVP_CIPHER_CTX_free(ctx.aesCtx)
 
-proc `=destroy`*(ctx: GcmCtx) =
+proc `=destroy`*(ctx: var GcmCtx) =
     EVP_CIPHER_CTX_free(ctx.aesCtx)
 
 template getCipher(mode: string, key: string): EVP_CIPHER =

--- a/nimutils/sha.nim
+++ b/nimutils/sha.nim
@@ -26,13 +26,13 @@ type
   Sha512Digest* = array[64, uint8]
   Sha3Digest*   = array[64, uint8]
 
-proc `=destroy`*(ctx: Sha256ctx) =
+proc `=destroy`*(ctx: var Sha256ctx) =
   EVP_MD_CTX_free(ctx.evpCtx)
 
-proc `=destroy`*(ctx: Sha512ctx) =
+proc `=destroy`*(ctx: var Sha512ctx) =
   EVP_MD_CTX_free(ctx.evpCtx)
 
-proc `=destroy`*(ctx: Sha3ctx) =
+proc `=destroy`*(ctx: var Sha3ctx) =
   EVP_MD_CTX_free(ctx.evpCtx)
 
 proc initSha256*(ctx: var Sha256CTX) =

--- a/nimutils/switchboard.nim
+++ b/nimutils/switchboard.nim
@@ -326,18 +326,18 @@ proc setExtraData*(ctx: var Party, extra: RootRef) =
   if extra != RootRef(nil):
     GC_ref(extra)
 
-proc `=destroy`*(ctx: Switchboard) =
+proc `=destroy`*(ctx: var Switchboard) =
   var copy = ctx
   copy.clearExtraData()
   copy.sb_destroy(false)
 
-proc `=destroy`*(ctx: Party) =
+proc `=destroy`*(ctx: var Party) =
   var copy = ctx
   copy.clearExtraData()
 
 proc sb_result_destroy(res: ptr SBCaptures) {.sb.}
 
-proc `=destroy`*(res: SBCaptures) =
+proc `=destroy`*(res: var SBCaptures) =
   sb_result_destroy(addr res)
 
 proc sb_result_get_capture(res: var SBCaptures, tag: cstring,


### PR DESCRIPTION
The Chalk repo (along with its dependencies nimutils/con4m) is currently using Nim 2.0.0 (released 2023-08-01). Upgrading to Nim 2.0.8 (released 2024-07-03) would guarantee that there's no unexpected behavior in Chalk that's due to Nim bugs that have been fixed upstream on the v2 branch in the last year. There are [about 300 commits of mostly small fixes](https://github.com/nim-lang/Nim/compare/v2.0.0...v2.0.8), but notably:

- Nim could previously generate C code that could no longer be compiled with recent stable releases of gcc and clang.
- Nim's default allocator had significant bugs.

And bumping is also good preparation for Nim 2.2.0, which is in the pipeline.

However, simply bumping Nim to 2.0.8 in Chalk [doesn't work](https://github.com/crashappsec/chalk/actions/runs/10009594554/job/27668836807?pr=378#step:7:802) because nimutils doesn't compile with newer Nim.

Before this PR, running `nimble build` in nimutils with Nim 2.0.8 would produce compiler errors of the form:

>/foo/nimutils/nimutils/sha.nim(29, 1) Error: signature for '=destroy' must be proc[T: object](x: var T)

and one error for:

>/foo/nimutils/nimutils/advisory_lock.nim(38, 23) Error: cannot convert -1 to uint64

Resolve those errors. The former errors occur only with the (non-default) `refc` memory management strategy, for which we opt in via this repo's `nimscript.nim`:

https://github.com/crashappsec/nimutils/blob/ca0bf746944f1106c4a537cc213ee58dfc456ba0/nimutils/nimscript.nim#L64-L69

Note however that with the `orc` memory management strategy (which is the default in Nim 2.0.0), this commit introduces deprecation warnings of the form:

>/foo/nimutils/nimutils/sha.nim(29, 1) Warning: A custom '=destroy' hook which takes a 'var T' parameter is deprecated; it should take a 'T' parameter [Deprecated]

It'd be possible to use conditional compilation such that the `var` is only present for `refc`. But let's just concern ourselves with `refc` for now, and remove `var` again if/when we move to `orc`.

This PR is necessary due to the below diff to `compiler/semstmts.nim` between Nim 2.0.0 and 2.0.8 (from [here](https://github.com/nim-lang/Nim/blob/v2.0.0/compiler/semstmts.nim#L1917-L1919) and [here](https://github.com/nim-lang/Nim/blob/v2.0.8/compiler/semstmts.nim#L1968-L1974)):

```diff
     of attachedDestructor:
-      localError(c.config, n.info, errGenerated,
-        "signature for '=destroy' must be proc[T: object](x: var T) or proc[T: object](x: T)")
+      if c.config.selectedGC in {gcArc, gcAtomicArc, gcOrc}:
+        localError(c.config, n.info, errGenerated,
+          "signature for '=destroy' must be proc[T: object](x: var T) or proc[T: object](x: T)")
+      else:
+        localError(c.config, n.info, errGenerated,
+          "signature for '=destroy' must be proc[T: object](x: var T)")
```

---

CI in PR https://github.com/crashappsec/nimutils/pull/71 (which bumps Nim to 2.0.8) fails before this PR, and passes when this PR's changes are applied.