### PR TITLE
ci: bump Nim from 2.0.0 to 2.0.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install Nim
-        uses: iffy/install-nim@049e1fad22d41813c77cff11ab8e1541a872014a
+        uses: iffy/install-nim@2546aaf825947f6bf76be75ff78d74176992e99d # 5.0.6
         with:
           version: "binary:2.0.0"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@2546aaf825947f6bf76be75ff78d74176992e99d # 5.0.6
         with:
-          version: "binary:2.0.0"
+          version: "binary:2.0.8"
         env:
           GITHUB_TOKEN: ${{ github.token }} # Avoid rate limiting.
 


### PR DESCRIPTION
Bump `iffy/install-nim` to a version that supports installing from `binary:2.0.8`, and then make CI run using Nim 2.0.8.

---

To-do:

- [x] Rebase on `main` after merging PR #70