### PR TITLE
build: allow building with recent C compilers

### DIFF
--- a/nimutils/nimscript.nim
+++ b/nimutils/nimscript.nim
@@ -71,9 +71,9 @@ template applyCommonLinkOptions*(staticLink = true, quiet = true) =
   switch("d", "useOpenSSL3")
   switch("cincludes", getEnv("HOME").joinPath("/.local/c0/include"))
   # Disable some errors for Clang 15+ and GCC 14+.
-  switch("passC", "-Wno-int-conversion")
-  switch("passC", "-Wno-implicit-function-declaration")
-  switch("passC", "-Wno-incompatible-pointer-types")
+  switch("passC", "-Wno-error=int-conversion")
+  switch("passC", "-Wno-error=implicit-function-declaration")
+  switch("passC", "-Wno-error=incompatible-pointer-types")
 
   setupTargetArch(quiet)
 

--- a/nimutils/nimscript.nim
+++ b/nimutils/nimscript.nim
@@ -70,6 +70,10 @@ template applyCommonLinkOptions*(staticLink = true, quiet = true) =
   switch("path", ".")
   switch("d", "useOpenSSL3")
   switch("cincludes", getEnv("HOME").joinPath("/.local/c0/include"))
+  # Disable some errors for Clang 15+ and GCC 14+.
+  switch("passC", "-Wno-int-conversion")
+  switch("passC", "-Wno-implicit-function-declaration")
+  switch("passC", "-Wno-incompatible-pointer-types")
 
   setupTargetArch(quiet)
 


### PR DESCRIPTION
TL;DR: We should be able to build Chalk outside a container without specifying extra compiler options. But this is currently not possible when recent C compilers (Clang: within the last couple of years; GCC: within the last few months) are installed, due to C compilation errors.

Fixing this would make building Chalk:

- Faster for a Chalk developer who prefers building natively locally
- More reliable in less reproducible environments

Right now, there's a significant subset of developers who would see errors if they cloned the Chalk repo and ran `nimble build`.

I suggest that we add three `passC` lines in nimutils to ~disable these errors~ downgrade these errors to warnings, and move on.

---

Before this PR, nimutils (and therefore Chalk, see https://github.com/crashappsec/chalk/issues/290) could not be built with recent stable releases of Clang and GCC, as some warnings now default to an error. This affected Clang 15.0.0 (2022-09-06) or later, and GCC 14.1 (2024-05-07) or later, and:

- Made it harder to build Chalk outside of a container during development. Simply writing the options from this PR on the command line after `nimble build` was not sufficient, because that wouldn't forward the options to the command used to compile e.g. this repo's `strcontainer.c` or `switchboard.c`.

- Would prevent certain OS or compiler version bumps for the builder image.

For now, simply ~disable these errors~ downgrade these errors to warnings. Some are in `md4c.h`, and others will be resolved when we move to libcon4m.

As background, see e.g. the [breaking changes section of the release notes for Clang 16](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes):

> - The `-Wimplicit-function-declaration` and `-Wimplicit-int` warnings now default to an error in C99, C11, and C17. As of C2x, support for implicit function declarations and implicit int has been removed, and the warning options will have no effect. Specifying `-Wimplicit-int` in C89 mode will now issue warnings instead of being a noop.

> - `-Wincompatible-function-pointer-types` now defaults to an error in all C language modes.

and [release notes for Clang 15](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html):

> - The `-Wint-conversion` warning diagnostic for implicit int <-> pointer conversions now defaults to an error in all C language modes.

and [the porting guide for GCC 14](https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors):

> The initial ISO C standard and its 1999 revision removed support for many C language features that were widely known as sources of application bugs due to accidental misuse. For backwards compatibility, GCC 13 and earlier diagnosed use of these features as warnings only. Although these warnings have been enabled by default for many releases, experience shows that these warnings are easily ignored, resulting in difficult to diagnose bugs. In GCC 14, these issues are now reported as errors, and no output file is created, providing clearer feedback to programmers that something is wrong.

> #### Implicit function declarations (`-Werror=implicit-function-declaration`)
> It is no longer possible to call a function that has not been declared. In general, the solution is to include a header file with an appropriate function prototype. Note that GCC will perform further type checks based on the function prototype, which can reveal further type errors that require additional changes.

> #### Using pointers as integers and vice versa (`-Werror=int-conversion`)
>GCC no longer treats integer types and pointer types as equivalent in assignments (including implied assignments of function arguments and return values), and instead fails the compilation with a type error.

> #### Type checking on pointer types (`-Werror=incompatible-pointer-types`)
>GCC no longer allows implicitly casting all pointer types to all other pointer types. This behavior is now restricted to the void * type and its qualified variations.

and the [Gentoo wiki page on Modern C porting](https://wiki.gentoo.org/wiki/Modern_C_porting).