### PR TITLE
enforcing aws client requests which will retry non-200 requests

### DIFF
--- a/nimutils/awsclient.nim
+++ b/nimutils/awsclient.nim
@@ -159,4 +159,10 @@ proc request*(client: var AwsClient, params: Table, headers: HttpHeaders = newHt
         client.httpClient.headers.table, client.scope)
     client.httpClient.headers.add("Authorization", auth)
 
-  return client.httpClient.safeRequest(url, action, payload, headers=headers)
+  return client.httpClient.safeRequest(
+    url,
+    action,
+    payload,
+    headers=headers,
+    only2xx=true,
+  )

--- a/nimutils/sinks.nim
+++ b/nimutils/sinks.nim
@@ -299,10 +299,7 @@ proc s3SinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
       newPath  = joinPath(state.objPath, newTail)
       response = client.put_object(state.bucket, newPath, msg)
 
-  if not response.code.is2xx():
-    raise newException(ValueError, response.status & ": " & response.body())
-  else:
-    cfg.iolog(t, "Post to: " & newPath & "; response = " & response.status)
+  cfg.iolog(t, "Post to: " & newPath & "; response = " & response.status)
 
 proc httpHeaders(cfg: SinkConfig): HttpHeaders =
   var

--- a/nimutils/stsclient.nim
+++ b/nimutils/stsclient.nim
@@ -45,8 +45,6 @@ proc getCallerIdentity*(self: var StsClient): StsCallerIdentity =
     ("Content-Type", "application/x-www-form-urlencoded"),
     ("Accept", "application/json"),
   ]))
-  if res.code != Http200:
-    raise newException(ValueError, res.status)
   let
     jsonResponse = parseJson(res.body())
     identity     = jsonResponse["GetCallerIdentityResponse"]["GetCallerIdentityResult"]


### PR DESCRIPTION
we are seeing some 401 in sts get-caller-identity for us-west-2 which might be related to iam being central so us-east-1 so a few retries might help the request to succeed