### PR TITLE
feat: add preferBundledCerts arg

### DIFF
--- a/nimutils/net.nim
+++ b/nimutils/net.nim
@@ -132,6 +132,8 @@ template withRetry(retries: int, firstRetryDelayMs: int, c: untyped) =
     try:
       c
       break
+    except SslError:
+      raise
     except:
       if attempts == retries:
         # reraise last exception to bubble error up
@@ -179,13 +181,18 @@ proc safeRequest(client: HttpClient,
 
 # https://github.com/nim-lang/Nim/blob/a45f43da3407dbbf8ecd15ce8ecb361af677add7/lib/pure/httpclient.nim#L380-L386
 # similar to stdlib but defaults to bundled CAs
-proc getSSLContext(caFile: string = "", verifyMode = CVerifyPeer): SslContext =
+proc getSSLContext(caFile:           string = "",
+                   verifyMode               = CVerifyPeer,
+                   preferBundledCerts: bool = false,
+                   ): SslContext =
   if caFile != "":
     # note when caFile is provided there is no try..except
     # otherwise we would silently fallback to bundled CA root store
     # if caFile is invalid/does not exist
     return newContext(verifyMode = verifyMode, caFile = caFile)
   else:
+    if preferBundledCerts:
+      return newContext(verifyMode = verifyMode, caFile = getCAStorePath())
     try:
       return newContext(verifyMode = verifyMode)
     except:
@@ -195,6 +202,7 @@ proc createHttpContext(uri: Uri = parseUri(""),
                        maxRedirects: int = 3,
                        timeout: int = 1000, # in ms - 1 second
                        pinnedCert: string = "",
+                       preferBundledCerts: bool = false,
                        verifyMode = CVerifyPeer,
                        disallowHttp: bool = false,
                        userAgent: string = defUserAgent,
@@ -210,7 +218,9 @@ proc createHttpContext(uri: Uri = parseUri(""),
     # always pass ssl context to client
     # as otherwise if http server returns redirect to https
     # nim segfaults vs throwing exception
-    context = getSSLContext(caFile = pinnedCert, verifyMode = verifyMode)
+    context = getSSLContext(caFile             = pinnedCert,
+                            verifyMode         = verifyMode,
+                            preferBundledCerts = preferBundledCerts)
     client  = newHttpClient(sslContext   = context,
                             userAgent    = userAgent,
                             timeout      = timeout,
@@ -231,6 +241,7 @@ proc safeRequest*(url: Uri | string,
                   firstRetryDelayMs: int = 0,
                   timeout: int = 1000,
                   pinnedCert: string = "",
+                  preferBundledCerts: bool = false,
                   verifyMode = CVerifyPeer,
                   maxRedirects: int = 3,
                   disallowHttp: bool = false,
@@ -243,13 +254,14 @@ proc safeRequest*(url: Uri | string,
   else:
     url
   let (context, client) = createHttpContext(
-    uri           = uri,
-    maxRedirects  = maxRedirects,
-    timeout       = timeout,
-    pinnedCert    = pinnedCert,
-    verifyMode    = verifyMode,
-    disallowHttp  = disallowHttp,
-    userAgent     = userAgent,
+    uri                = uri,
+    maxRedirects       = maxRedirects,
+    timeout            = timeout,
+    pinnedCert         = pinnedCert,
+    verifyMode         = verifyMode,
+    disallowHttp       = disallowHttp,
+    userAgent          = userAgent,
+    preferBundledCerts = preferBundledCerts,
   )
   try:
     return client.safeRequest(url               = uri,
@@ -262,6 +274,32 @@ proc safeRequest*(url: Uri | string,
                               firstRetryDelayMs = firstRetryDelayMs,
                               only2xx           = only2xx,
                               raiseWhenAbove    = raiseWhenAbove)
+
+  except SslError:
+    if pinnedCert != "" or not preferBundledCerts:
+      raise
+    # retry without bundled certs preference which will
+    # attempt to use system root certs
+    return safeRequest(
+      url                = uri,
+      httpMethod         = httpMethod,
+      body               = body,
+      headers            = headers,
+      multipart          = multipart,
+      retries            = retries,
+      connectRetries     = connectRetries,
+      firstRetryDelayMs  = firstRetryDelayMs,
+      timeout            = timeout,
+      pinnedCert         = pinnedCert,
+      preferBundledCerts = false,
+      verifyMode         = verifyMode,
+      maxRedirects       = maxRedirects,
+      disallowHttp       = disallowHttp,
+      only2xx            = only2xx,
+      raiseWhenAbove     = raiseWhenAbove,
+      userAgent          = userAgent,
+    )
+
   finally:
     context.destroyContext()
     client.close()

--- a/nimutils/sinks.nim
+++ b/nimutils/sinks.nim
@@ -336,38 +336,43 @@ proc httpParams(cfg: SinkConfig): tuple[
   timeout: int,
   disallowHttp: bool,
   pinnedCert: string,
+  preferBundledCerts: bool,
 ] =
   let
     uri          = parseURI(cfg.params["uri"])
     headers      = cfg.httpHeaders()
     disallowHttp = "disallow_http" in cfg.params
   var
-    timeout    = 1000 # in ms - 1 second
-    pinnedCert = ""
+    timeout            = 1000 # in ms - 1 second
+    pinnedCert         = ""
+    preferBundledCerts = false
   if "pinned_cert_file" in cfg.params:
     pinnedCert = cfg.params["pinned_cert_file"]
-  if "timeout" in cfg.params:
+  elif "prefer_bundled_certs" in cfg.params:
+    preferBundledCerts = cfg.params["prefer_bundled_certs"] == "true"
+  elif "timeout" in cfg.params:
     let paramstr = cfg.params["timeout"]
     if parseInt(paramstr, timeout) != len(paramstr):
       raise newException(ValueError, "Timeout must be miliseconds " &
                          "represented as an integer, or 0 for no timeout.")
     elif timeout <= 0:
       timeout = -1
-  return (uri, headers, timeout, disallowHttp, pinnedCert)
+  return (uri, headers, timeout, disallowHttp, pinnedCert, preferBundledCerts)
 
 proc postSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable) =
   let
     params   = cfg.httpParams()
-    response = safeRequest(url               = params.uri,
-                           timeout           = params.timeout,
-                           headers           = params.headers,
-                           disallowHttp      = params.disallowHttp,
-                           pinnedCert        = params.pinnedCert,
-                           httpMethod        = HttpPost,
-                           body              = msg,
-                           retries           = 2,
-                           firstRetryDelayMs = 100,
-                           only2xx           = true)
+    response = safeRequest(url                = params.uri,
+                           timeout            = params.timeout,
+                           headers            = params.headers,
+                           disallowHttp       = params.disallowHttp,
+                           pinnedCert         = params.pinnedCert,
+                           preferBundledCerts = params.preferBundledCerts,
+                           httpMethod         = HttpPost,
+                           body               = msg,
+                           retries            = 2,
+                           firstRetryDelayMs  = 100,
+                           only2xx            = true)
 
   cfg.iolog(t, "Post " & response.status)
 
@@ -381,16 +386,17 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
     # and will only send it to the returned signed URL
     # which is why we disallow redirects here via maxRedirects
     # NOTE this assumes that the endpoint immediately returns presigned URL
-    signResponse = safeRequest(url               = params.uri,
-                               timeout           = params.timeout,
-                               headers           = params.headers,
-                               disallowHttp      = params.disallowHttp,
-                               pinnedCert        = params.pinnedCert,
-                               httpMethod        = HttpPut,
-                               retries           = 2,
-                               firstRetryDelayMs = 100,
-                               maxRedirects      = 0,
-                               raiseWhenAbove    = 500)
+    signResponse = safeRequest(url                = params.uri,
+                               timeout            = params.timeout,
+                               headers            = params.headers,
+                               disallowHttp       = params.disallowHttp,
+                               pinnedCert         = params.pinnedCert,
+                               preferBundledCerts = params.preferBundledCerts,
+                               httpMethod         = HttpPut,
+                               retries            = 2,
+                               firstRetryDelayMs  = 100,
+                               maxRedirects       = 0,
+                               raiseWhenAbove     = 500)
 
   if signResponse.code notin [Http302, Http307]:
     raise newException(ValueError, "Presign requires 302/307 redirect but received: " & signResponse.status)
@@ -404,15 +410,16 @@ proc presignSinkOut(msg: string, cfg: SinkConfig, t: Topic, ignored: StringTable
     raise newException(ValueError, "Presign edirect Location header needs to be absolute URL")
 
   let
-    response = safeRequest(url               = uri,
-                           timeout           = params.timeout,
-                           disallowHttp      = params.disallowHttp,
-                           pinnedCert        = params.pinnedCert,
-                           httpMethod        = HttpPut,
-                           body              = msg,
-                           retries           = 2,
-                           firstRetryDelayMs = 100,
-                           only2xx           = true)
+    response = safeRequest(url                = uri,
+                           timeout            = params.timeout,
+                           disallowHttp       = params.disallowHttp,
+                           pinnedCert         = params.pinnedCert,
+                           preferBundledCerts = params.preferBundledCerts,
+                           httpMethod         = HttpPut,
+                           body               = msg,
+                           retries            = 2,
+                           firstRetryDelayMs  = 100,
+                           only2xx            = true)
 
   cfg.iolog(t, "Presign " & response.status)
 
@@ -475,13 +482,14 @@ proc addPostSink*() =
   var
     record = SinkImplementation()
     keys = {
-      "uri"              : true,
-      "content_type"     : true,
-      "disallow_http"    : false,
-      "headers"          : false,
-      "timeout"          : false,
-      "pinned_cert_file" : false,
-      "auth"             : false,
+      "uri"                  : true,
+      "content_type"         : true,
+      "disallow_http"        : false,
+      "headers"              : false,
+      "timeout"              : false,
+      "pinned_cert_file"     : false,
+      "prefer_bundled_certs" : false,
+      "auth"                 : false,
     }.toTable()
 
   record.outputFunction = postSinkOut
@@ -493,13 +501,14 @@ proc addPresignSink*() =
   var
     record = SinkImplementation()
     keys = {
-      "uri"              : true,
-      "content_type"     : true,
-      "disallow_http"    : false,
-      "headers"          : false,
-      "timeout"          : false,
-      "pinned_cert_file" : false,
-      "auth"             : false,
+      "uri"                  : true,
+      "content_type"         : true,
+      "disallow_http"        : false,
+      "headers"              : false,
+      "timeout"              : false,
+      "pinned_cert_file"     : false,
+      "prefer_bundled_certs" : false,
+      "auth"                 : false,
     }.toTable()
 
   record.outputFunction = presignSinkOut


### PR DESCRIPTION
this allows to prefer bundled root certs and if they fail, fallback to system root certs

this will allow to make TLS connections without accessing system certs for better cert usage detection